### PR TITLE
Allow scoping when retrieving element lists

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -173,15 +173,16 @@ class PolicyMachine
 
     ##
     # Define an "all" method for each policy element type, as in .users or .object_attributes
-    # This will return all persisted of the elements of this type.
+    # This will return all persisted of the elements of this type. If an options hash is passed
+    # then only elements that match all specified attributes will be returned.
     #
-    define_method(pe_type.pluralize) do
+    define_method(pe_type.pluralize) do |options = {}|
       # TODO:  We might want to scope by the uuid of this policy machine in the request to the persistent store, rather than
       # here, after records have already been retrieved.
       # TODO: When the policy machine raises a NoMethoError, we should log a nice message
       # saying that the underlying policy element class doesn't implement 'all'.  Do
       # it when we have a logger, though.
-      all_found = pm_class.send(:all, @policy_machine_storage_adapter)
+      all_found = pm_class.send(:all, @policy_machine_storage_adapter, options)
       all_found.select{ |pe| pe.policy_machine_uuid == uuid }
     end
   end

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -139,8 +139,8 @@ module PM
     end
 
     # Return all policy elements of a particular type (e.g. all users)
-    def self.all(pm_storage_adapter)
-      pm_storage_adapter.find_all_of_type_user.map do |stored_pe|
+    def self.all(pm_storage_adapter, options = {})
+      pm_storage_adapter.find_all_of_type_user(options).map do |stored_pe|
         convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::User)
       end
     end
@@ -160,8 +160,8 @@ module PM
     end
 
      # Return all policy elements of a particular type (e.g. all users)
-    def self.all(pm_storage_adapter)
-      pm_storage_adapter.find_all_of_type_user_attribute.map do |stored_pe|
+    def self.all(pm_storage_adapter, options = {})
+      pm_storage_adapter.find_all_of_type_user_attribute(options).map do |stored_pe|
         convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::UserAttribute)
       end
     end
@@ -189,8 +189,8 @@ module PM
       end
     end
 
-    def self.all(pm_storage_adapter)
-      pm_storage_adapter.find_all_of_type_object_attribute.map do |stored_pe|
+    def self.all(pm_storage_adapter, options = {})
+      pm_storage_adapter.find_all_of_type_object_attribute(options).map do |stored_pe|
         convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::ObjectAttribute)
       end
     end
@@ -210,8 +210,8 @@ module PM
     end
 
     # Return all policy elements of a particular type (e.g. all users)
-    def self.all(pm_storage_adapter)
-      pm_storage_adapter.find_all_of_type_object.map do |stored_pe|
+    def self.all(pm_storage_adapter, options = {})
+      pm_storage_adapter.find_all_of_type_object(options).map do |stored_pe|
         convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::Object)
       end
     end
@@ -231,8 +231,8 @@ module PM
     end
 
     # Return all policy elements of a particular type (e.g. all users)
-    def self.all(pm_storage_adapter)
-      pm_storage_adapter.find_all_of_type_operation.map do |stored_pe|
+    def self.all(pm_storage_adapter, options = {})
+      pm_storage_adapter.find_all_of_type_operation(options).map do |stored_pe|
         convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::Operation)
       end
     end

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -24,8 +24,17 @@ module PolicyMachineStorageAdapter
         persisted_pe
       end
 
-      define_method("find_all_of_type_#{pe_type}") do
-        policy_elements.select{ |pe| pe.pe_type == pe_type }
+      define_method("find_all_of_type_#{pe_type}") do |options = {}|
+        conditions = options.merge(pe_type: pe_type)
+        policy_elements.select do |pe|
+          conditions.all? do |k,v|
+            if v.nil?
+              !pe.respond_to?(k) || pe.send(k) == nil
+            else
+              pe.respond_to?(k) && pe.send(k) == v
+            end
+          end
+        end
       end
     end
 

--- a/lib/policy_machine_storage_adapters/neography.rb
+++ b/lib/policy_machine_storage_adapters/neography.rb
@@ -35,9 +35,18 @@ module PolicyMachineStorageAdapter
         persisted_pe
       end
       
-      define_method("find_all_of_type_#{pe_type}") do
+      define_method("find_all_of_type_#{pe_type}") do |options = {}|
         found_elts = ::Neography::Node.find('policy_element_types', 'pe_type', pe_type)
-        found_elts.nil? ? [] : [found_elts].flatten
+        found_elts = found_elts.nil? ? [] : [found_elts].flatten
+        found_elts.select do |elt|
+          options.all? do |k,v|
+            if v.nil?
+              !elt.respond_to?(k)
+            else
+              elt.respond_to?(k) && elt.send(k) == v
+            end
+          end
+        end
       end
     end
     

--- a/lib/policy_machine_storage_adapters/template.rb
+++ b/lib/policy_machine_storage_adapters/template.rb
@@ -42,26 +42,26 @@ module PolicyMachineStorageAdapter
 
     ##
     # The following find_* methods should return an array of persisted
-    # policy elements of the given type (e.g. user or object_attribute).
+    # policy elements of the given type (e.g. user or object_attribute) and extra attributes.
     # If no such persisted policy elements are found, the empty array should
     # be returned.
     #
-    def find_all_of_type_user
+    def find_all_of_type_user(options = {})
 
     end
-    def find_all_of_type_user_attribute
+    def find_all_of_type_user_attribute(options = {})
 
     end
-    def find_all_of_type_object
+    def find_all_of_type_object(options = {})
 
     end
-    def find_all_of_type_object_attribute
+    def find_all_of_type_object_attribute(options = {})
 
     end
-    def find_all_of_type_operation
+    def find_all_of_type_operation(options = {})
 
     end
-    def find_all_of_type_policy_class
+    def find_all_of_type_policy_class(options = {})
 
     end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -14,6 +14,36 @@ describe 'ActiveRecord' do
   describe PolicyMachineStorageAdapter::ActiveRecord do
     it_behaves_like 'a policy machine storage adapter with required public methods'
     it_behaves_like 'a policy machine storage adapter'
+    let(:policy_machine_storage_adapter) { described_class.new }
+
+    describe 'find_all_of_type' do
+
+      it 'warns when filtering on an extra attribute' do
+        policy_machine_storage_adapter.should_receive(:warn).once
+        policy_machine_storage_adapter.find_all_of_type_user(foo: 'bar').should be_empty
+      end
+
+      context 'an extra attribute column has been added to the database' do
+
+        it 'does not warn' do
+          policy_machine_storage_adapter.should_not_receive(:warn)
+          policy_machine_storage_adapter.find_all_of_type_user(color: 'red').should be_empty
+        end
+
+        it 'only returns elements that match the hash' do
+          policy_machine_storage_adapter.add_object('some_uuid1', 'some_policy_machine_uuid1')
+          policy_machine_storage_adapter.add_object('some_uuid2', 'some_policy_machine_uuid1', color: 'red')
+          policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1', color: 'blue')
+          policy_machine_storage_adapter.find_all_of_type_object(color: 'red').should be_one
+          policy_machine_storage_adapter.find_all_of_type_object(color: nil).should be_one
+          policy_machine_storage_adapter.find_all_of_type_object(color: 'green').should be_none
+          policy_machine_storage_adapter.find_all_of_type_object(color: 'blue').map(&:color).should eql(['blue'])
+        end
+
+      end
+
+    end
+
   end
 
   describe 'PolicyMachine integration with PolicyMachineStorageAdapter::ActiveRecord' do

--- a/spec/support/shared_examples_policy_machine_spec.rb
+++ b/spec/support/shared_examples_policy_machine_spec.rb
@@ -261,6 +261,17 @@ shared_examples "a policy machine" do
         policy_machine.users.last.foo.should == 'bar'
       end
 
+      it 'allows searching on any extra attribute keys' do
+        policy_machine.create_user('u1', foo: 'bar')
+        policy_machine.create_user('u2', foo: nil, attitude: 'sassy')
+        silence_warnings do
+          policy_machine.users(foo: 'bar').should be_one
+          policy_machine.users(foo: nil).should be_one
+          policy_machine.users(foo: 'baz').should be_none
+          policy_machine.users(foo: 'bar', attitude: 'sassy').should be_none
+        end
+      end
+
     end
 
   end

--- a/test/dummy/db/migrate/20131021221759_add_color_to_policy_element.rb
+++ b/test/dummy/db/migrate/20131021221759_add_color_to_policy_element.rb
@@ -1,0 +1,5 @@
+class AddColorToPolicyElement < ActiveRecord::Migration
+  def change
+    add_column :policy_elements, :color, :string
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131015214828) do
+ActiveRecord::Schema.define(:version => 20131021221759) do
 
   create_table "assignments", :force => true do |t|
     t.integer "parent_id", :null => false
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(:version => 20131015214828) do
     t.string "policy_machine_uuid"
     t.string "type",                :null => false
     t.text   "extra_attributes"
+    t.string "color"
   end
 
   add_index "policy_elements", ["type"], :name => "index_policy_elements_on_type"


### PR DESCRIPTION
Allows you to do 

``` ruby
PolicyMachine.users(foo: 'bar', attitude: 'sassy')
```

and get a scoped result.

To make this performant with the active_record adapter, it allows extra_attributes that correspond to a column in the table to be stored in that column, and warns if you're searching on an un-columned attribute.

Finished in 2 minutes 4.97 seconds
681 examples, 0 failures
