### PR TITLE
Support transactions in active_record and in_memory backends

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -187,6 +187,14 @@ class PolicyMachine
     end
   end
 
+  ##
+  # Execute the passed-in block transactionally: any error raised out of the block causes
+  # all the block's changes to be rolled back.
+  # TODO: Possibly rescue NotImplementError and warn.
+  def transaction(&block)
+    policy_machine_storage_adapter.transaction(&block)
+  end
+
   private
 
     # Raise unless the argument is a policy element.

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -287,6 +287,13 @@ module PolicyMachineStorageAdapter
       user.descendants.where(type: class_for_type('user_attribute'))
     end
 
+    ##
+    # Execute the passed-in block transactionally: any error raised out of the block causes
+    # all the block's changes to be rolled back.
+    def transaction(&block)
+      PolicyElement.transaction(&block)
+    end
+
     private
 
     def assert_persisted_policy_element(*arguments)

--- a/lib/policy_machine_storage_adapters/neography.rb
+++ b/lib/policy_machine_storage_adapters/neography.rb
@@ -212,6 +212,13 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    ##
+    # Execute the passed-in block transactionally: any error raised out of the block causes
+    # all the block's changes to be rolled back.
+    def transaction
+      raise NotImplementedError, "transactions are only available in neo4j 2.0 which #{self.class} is not compatible with"
+    end
+
     private
     
       # Raise argument error if argument is not suitable for consumption in

--- a/lib/policy_machine_storage_adapters/template.rb
+++ b/lib/policy_machine_storage_adapters/template.rb
@@ -158,5 +158,12 @@ module PolicyMachineStorageAdapter
     def user_attributes_for_user(user)
     end
 
+    ##
+    # Execute the passed-in block transactionally: any error raised out of the block causes
+    # all the block's changes to be rolled back. Should raise NotImplementedError if the
+    # persistence layer does not support this.
+    def transaction
+    end
+
   end
 end

--- a/spec/support/shared_examples_storage_adapter_public_methods.rb
+++ b/spec/support/shared_examples_storage_adapter_public_methods.rb
@@ -9,7 +9,7 @@ shared_examples "a policy machine storage adapter with required public methods" 
     required_public_methods << "add_#{pe_type}"
     required_public_methods << "find_all_of_type_#{pe_type}"
   end
-  required_public_methods += %w(assign connected? unassign delete update element_in_machine? add_association associations_with policy_classes_for_object_attribute)
+  required_public_methods += %w(assign connected? unassign delete update element_in_machine? add_association associations_with policy_classes_for_object_attribute transaction)
 
   required_public_methods.each do |req_public_method|
     it "responds to #{req_public_method}" do

--- a/spec/support/storage_adapter_helpers.rb
+++ b/spec/support/storage_adapter_helpers.rb
@@ -1,0 +1,7 @@
+# This file contains helper methods to test policy machine integration with storage adapters.
+
+def if_implements(storage_adapter, meth, *args,&block)
+  storage_adapter.send(meth,*args,&block)
+rescue NotImplementedError => e
+  pending(e.message)
+end


### PR DESCRIPTION
When the database supports it, allow PolicyMachine operations to be done transactionally, ActiveRecord style:

``` ruby
@policy_machine.transaction do
  @policy_machine.create_object(o)
  @policy_machine.create_object_attribute(oa)
  @policy_machine.add_assignment(o,oa)
end
```

Spec output is now: 
Finished in 50.53 seconds
699 examples, 0 failures, 4 pending

with the 4 pending being neography transaction specs; neo4j 1.9 doesn't support transactions, and something about our adapter doesn't play well with neo4j 2.0.
