### PR TITLE
Accept strings/symbols in is_privilege? to avoid having to serialize operations

### DIFF
--- a/spec/support/policy_machine_helpers.rb
+++ b/spec/support/policy_machine_helpers.rb
@@ -27,7 +27,7 @@ def assert_pm_scoped_privilege_expectations
   users_or_attributes = policy_machine.users | policy_machine.user_attributes
   objects_or_attributes = policy_machine.objects | policy_machine.object_attributes
   users_or_attributes.product(objects_or_attributes) do |u, o|
-    expected_scoped_privileges = policy_machine.operations.grep(->op{policy_machine.is_privilege?(u, op, o)}) do |op|
+    expected_scoped_privileges = policy_machine.operations.grep(->op{policy_machine.is_privilege?(u, op.unique_identifier, o)}) do |op|
       [u, op, o]
     end
     policy_machine.scoped_privileges(u,o).should =~ expected_scoped_privileges

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -306,9 +306,9 @@ shared_examples "a policy machine" do
         to raise_error(ArgumentError, "user_attribute_pe must be a User or UserAttribute.")
     end
 
-    it 'raises when the second argument is not an operation' do
+    it 'raises when the second argument is not an operation, symbol, or string' do
       expect{ policy_machine.is_privilege?(@u1, @u1, @o1)}.
-        to raise_error(ArgumentError, "operation must be an Operation.")
+        to raise_error(ArgumentError, "operation must be an Operation, Symbol, or String.")
     end
 
     it 'raises when the third argument is not an object or object_attribute' do
@@ -330,6 +330,22 @@ shared_examples "a policy machine" do
 
     it 'returns false if privilege cannot be inferred from arguments' do
       policy_machine.is_privilege?(@u1, @w, @o2).should be_false
+    end
+
+    it 'accepts the unique identifier for an operation in place of the operation' do
+      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o1).should be_true
+    end
+
+    it 'accepts the unique identifier in symbol form for an operation in place of the operation' do
+      policy_machine.is_privilege?(@u1, @w.unique_identifier.to_sym, @o1).should be_true
+    end
+
+    it 'returns false on string input when the operation exists but the privilege does not' do
+      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o2).should be_false
+    end
+
+    it 'returns false on string input when the operation does not exist' do
+      policy_machine.is_privilege?(@u1, 'non-existent-operation', @o2).should be_false
     end
 
     it 'does not infer privileges from deleted attributes' do


### PR DESCRIPTION
Modifies PolicyMachine `is_privilege?` to accept the string "write" instead of a `PM::Operation` object with uuid "write", and modifies the optimized `is_privilege?` method in the ActiveRecord adapter so that sticks the string into its where condition rather than fetching the object from the database. This prevents a stateless consumer of the policy machine from needing to fetch the operation from the database before calling `is_privilege?`, which should reduce overhead.

In theory one could do this with the user and the object too, but it's nontrivial. 

```
Finished in 1 minute 49.15 seconds
726 examples, 0 failures, 4 pending
Coverage report generated for RSpec to /Users/aweiner/the_policy_machine/coverage. 664 / 666 LOC (99.7%) covered.
```
