### PR TITLE
Modified to update gemspec to update to rails 3.2

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -100,6 +100,7 @@ module PolicyMachineStorageAdapter
     end
 
     class Assignment < ::ActiveRecord::Base
+      attr_accessible :child_id
       # needs parent_id, child_id columns
       after_create :add_to_transitive_closure
       after_destroy :remove_from_transitive_closure

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -11,13 +11,13 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency('activesupport')
+  s.add_dependency('activesupport', '~> 3.2')
 
   s.add_development_dependency('rspec', '~> 2.13.0')
   s.add_development_dependency('simplecov', '~> 0.7.1')
   s.add_development_dependency('debugger', '~> 1.6.0')
   s.add_development_dependency('neography', '~> 1.1')
-  s.add_development_dependency('rails')
+  s.add_development_dependency('rails', '~> 3.2')
   s.add_development_dependency('mysql2')
   s.add_development_dependency('database_cleaner')
 


### PR DESCRIPTION
CONTRIBUTING update in later PR

534 examples, 0 failures
Coverage report generated for RSpec to /Users/yzhang/the_policy_machine/coverage. 572 / 574 LOC (99.65%) covered.
