### PR TITLE
Modified to trim leading and trailing whitespace in extra attributes for find AR adapter and all attributes for find in mem adapter

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -176,8 +176,15 @@ module PolicyMachineStorageAdapter
           warn "WARNING: #{self.class} is filtering #{pe_type} on #{key} in memory, which won't scale well. " <<
             "To move this query to the database, add a '#{key}' column to the policy_elements table " <<
             "and re-save existing records"
-          all.select!{ |pe| pe.methodize_extra_attributes_hash and 
-            ((attr_value = pe.extra_attributes_hash[key]).is_a?(String) and value.is_a?(String) and options[:ignore_case]) ? attr_value.downcase == value.downcase : attr_value == value}
+          all.select! do |pe| 
+            if pe.methodize_extra_attributes_hash
+              if (attr_value = pe.extra_attributes_hash[key]).is_a?(String) and value.is_a?(String) 
+                options[:ignore_case] ? attr_value.strip.downcase == value.strip.downcase : attr_value.strip == value.strip
+              else
+                attr_value == value
+              end
+            end
+          end
         end
         # Default to first page if not specified
         if options[:per_page]

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -36,7 +36,11 @@ module PolicyMachineStorageAdapter
               !pe.respond_to?(k) || pe.send(k) == nil
             else
               pe.respond_to?(k) && 
-                ((pe.send(k).is_a?(String) && v.is_a?(String) && options[:ignore_case]) ? pe.send(k).downcase == v.downcase : pe.send(k) == v)
+                if pe.send(k).is_a?(String) && v.is_a?(String)
+                  options[:ignore_case] ? pe.send(k).strip.downcase == v.strip.downcase : pe.send(k).strip == v.strip
+                else
+                  pe.send(k) == v
+                end
             end
           end
         end

--- a/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
+++ b/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
@@ -35,7 +35,7 @@ shared_examples "a policy machine storage adapter" do
         policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}").should == [node1, node2]
       end
       
-      context 'case sensitivity' do
+      context 'finding matches strings' do
         before do
           ['abcde', 'object1'].each do |name| 
             policy_machine_storage_adapter.add_object("#{name}_uuid", 'some_policy_machine_uuid', name: name) 
@@ -50,6 +50,13 @@ shared_examples "a policy machine storage adapter" do
         it 'finds without case sensitivity if the option is passed' do
           expect(policy_machine_storage_adapter.find_all_of_type_object(name: 'ABCDE', ignore_case: true).first.unique_identifier).to eq('abcde_uuid')
           expect(policy_machine_storage_adapter.find_all_of_type_object(name: 'oBJECt1', ignore_case: true).first.unique_identifier).to eq('object1_uuid')
+        end
+        
+        it 'finds with whitespace trimming' do
+          expect(policy_machine_storage_adapter.find_all_of_type_object(name: '  abcde  ').first.unique_identifier).to eq('abcde_uuid')
+          expect(policy_machine_storage_adapter.find_all_of_type_object(name: '   object1').first.unique_identifier).to eq('object1_uuid')
+          expect(policy_machine_storage_adapter.find_all_of_type_object(name: '  ABCDE  ', ignore_case: true).first.unique_identifier).to eq('abcde_uuid')
+          expect(policy_machine_storage_adapter.find_all_of_type_object(name: '   oBJECt1', ignore_case: true).first.unique_identifier).to eq('object1_uuid')
         end
       end
     end


### PR DESCRIPTION
576 examples, 0 failures
Coverage report generated for RSpec to /Users/yzhang/the_policy_machine/coverage. 606 / 610 LOC (99.34%) covered.
