### PR TITLE
[MCC-110306] Fix MySQL Deadlocks

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -114,6 +114,7 @@ module PolicyMachineStorageAdapter
       def add_to_transitive_closure
         connection.execute("Insert ignore into transitive_closure values (#{parent_id}, #{child_id})")
 
+        # Note: select/insert statements executed separately to avoid deadlock caused by InnoDB taking shared locks and all selected rows
         selected_pairs = connection.execute(
             "Select distinct parents_ancestors.ancestor_id, childs_descendants.descendant_id from
                transitive_closure parents_ancestors,
@@ -137,6 +138,7 @@ module PolicyMachineStorageAdapter
           not exists (Select NULL from assignments where parent_id=ancestor_id and child_id=descendant_id)
         ")
 
+        # Note: select/insert statements executed separately to avoid deadlock caused by InnoDB taking shared locks and all selected rows
         selected_pairs = connection.execute(
            "Select ancestors_surviving_relationships.ancestor_id, descendants_surviving_relationships.descendant_id
             from
@@ -151,7 +153,7 @@ module PolicyMachineStorageAdapter
       end
 
       private
-        # insert (with ignore) the given ancestor_id, descendant_id pairs 
+        # Insert (with ignore) the given ancestor_id, descendant_id pairs 
         def insert_transitive_closures(id_pairs)
           if (id_pairs.any?)
             insert_stmt = "Insert ignore into transitive_closure values "


### PR DESCRIPTION
This PR addresses the deadlocks seen in validation environment, and reproduced consistently in performance environment (by the role assignment create test). Essentially the problem is the cross join locks a large number of rows, and deadlocks the transaction when two concurrent requests are made to `add_to_transitive_closure` with the same parent_id.

My investigation (and experimentation - thanks to @csavage-mdsol great repro test!) found that although the transaction is in "Repeatable Read", normally allowing reads to occur w/o locking, InnoDB will take shared locks on reads (as if it was "Read Committed") in certain scenarios with "insert - select" statements.

Breaking up the transaction so that `add_to_transitive_closure` is its own transaction will also work, however that will remove the atomic update of the assignment.
Simply breaking up the select from the insert seems the best approach. I could not reproduce the deadlock after this change (and before the change it would occur 100 times in the same test consistently).

Other minor changes:
- added "distinct" to select clause (at least in performance, there was dramatic duplication of entries)
- changed `select *` to `select NULL` (more idiomatic sql, and skips a second read on the clustered index, if assignment table ever changed).

@HonoreDB @csavage-mdsol @yzhangmedidata  please review.
@mszenher fyi.

Finished in 15.57 seconds
564 examples, 0 failures
Coverage report generated for RSpec to /Users/smyers/mdsol/the_policy_machine/coverage. 628 / 706 LOC (88.95%) covered.
