### PR TITLE
Actually order when paginating, with no args it's a no-op

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -182,7 +182,7 @@ module PolicyMachineStorageAdapter
         # Default to first page if not specified
         if options[:per_page]
           page = options[:page] ? options[:page] : 1
-          paginated_all = all.order.paginate(page: page, per_page: options[:per_page])
+          paginated_all = all.order(:id).paginate(page: page, per_page: options[:per_page])
         end
         paginated_all = all unless paginated_all
         unless paginated_all.respond_to? :total_entries


### PR DESCRIPTION
@yzhangmedidata The call to `.order` [doesn't actually do anything with no args in Rails 3](http://apidock.com/rails/v3.2.13/ActiveRecord/QueryMethods/order). We missed this for a while because MySQL usually returns items in ascending order by id anyway. But when it's using a different index, the order becomes non-deterministic, which obviously is unacceptable when paginating. `order(:id)` solves the problem.

Specs pass, except for the Neo ones that were already broken.
