### PR TITLE
Fix/postgresql deadlocks

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -163,9 +163,9 @@ class PolicyMachine
   # object (attribute).
   #
   # TODO:  might make privilege a class of its own
-  def scoped_privileges(user_or_attribute, object_or_attribute)
+  def scoped_privileges(user_or_attribute, object_or_attribute, options = {})
     if policy_machine_storage_adapter.respond_to?(:scoped_privileges)
-      policy_machine_storage_adapter.scoped_privileges(user_or_attribute.stored_pe, object_or_attribute.stored_pe).map do |op|
+      policy_machine_storage_adapter.scoped_privileges(user_or_attribute.stored_pe, object_or_attribute.stored_pe, options).map do |op|
         operation = PM::Operation.convert_stored_pe_to_pe(op, policy_machine_storage_adapter, PM::Operation)
         [user_or_attribute, operation, object_or_attribute]
       end

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -22,7 +22,7 @@ module PolicyMachineStorageAdapter
     class Assignment
 
       def add_to_transitive_closure
-        connection.execute('Lock transitive_closure in share mode')
+        connection.execute('Lock transitive_closure in share row exclusive mode')
         connection.execute("Insert into transitive_closure
           select #{parent_id}, #{child_id}
           where not exists (Select NULL from transitive_closure preexisting where preexisting.ancestor_id=#{parent_id} and preexisting.descendant_id=#{child_id})")
@@ -38,7 +38,7 @@ module PolicyMachineStorageAdapter
       end
 
       def remove_from_transitive_closure
-        connection.execute('Lock transitive_closure in share mode')
+        connection.execute('Lock transitive_closure in share row exclusive mode')
         parents_ancestors = connection.execute("Select ancestor_id from transitive_closure where descendant_id=#{parent_id}")
         childs_descendants = connection.execute("Select descendant_id from transitive_closure where ancestor_id=#{child_id}")
         parents_ancestors = parents_ancestors.values.<<(parent_id).join(',')


### PR DESCRIPTION
Merges feature/postgres into master, and strengthens the lock mode to reduce deadlocks. `share mode` appears to be a mistake according to postgres docs:

>If a transaction of this sort is going to change the data in the table, then it should use SHARE ROW EXCLUSIVE lock mode instead of SHARE mode. This ensures that only one transaction of this type runs at a time. Without this, a deadlock is possible: two transactions might both acquire SHARE mode, and then be unable to also acquire ROW EXCLUSIVE mode to actually perform their updates.

Tests pass.