### PR TITLE
Use tail recursive SQL in Postgres

### DIFF
--- a/lib/generators/policy_machine/templates/migration.rb
+++ b/lib/generators/policy_machine/templates/migration.rb
@@ -16,6 +16,7 @@ class GeneratePolicyMachine < ActiveRecord::Migration
     end
     add_index :policy_element_associations, [:user_attribute_id, :object_attribute_id], name: 'index_pe_assocs_on_ua_and_oa'
 
+    #TODO: If we end up not using this table in Postgres, make creating it conditional on the database type
     create_table :transitive_closure, id: false do |t|
       t.integer :ancestor_id, null: false
       t.integer :descendant_id, null: false

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -1,66 +1,32 @@
-# Simple postgresql transitive closure implementation
-# TODO: Look into taking better advantage of Postgres for this
+require 'active_record/hierarchical_query' # via gem activerecord-hierarchical_query
 
 module PolicyMachineStorageAdapter
-  class ActiveRecord     
-     
-      # This is required due to postgres not supporting insert ignore for uniqueness constraints
-      # TODO: Look into moving insert ignore sql into active record postgres adapter code and removing this
-      def assign(src, dst)
-        assert_persisted_policy_element(src, dst)
-        src_id, dst_id = src.id, dst.id
-        transaction do
-          # TODO: Look into rewriting using binded parameterized sql
-          result = Assignment.connection.execute("Insert into assignments (child_id, parent_id)
-            select #{dst_id}, #{src_id} 
-            where not exists (select id from assignments preexisting where preexisting.child_id=#{dst_id} and preexisting.parent_id=#{src_id})
-            returning id")
-            Assignment.new(parent_id: src_id, child_id: dst_id).add_to_transitive_closure if result.values.present?
-          end
-      end
-    
-    class Assignment
+  class ActiveRecord
 
-      def add_to_transitive_closure
-        connection.execute('Lock transitive_closure in share row exclusive mode')
-        connection.execute("Insert into transitive_closure
-          select #{parent_id}, #{child_id}
-          where not exists (Select NULL from transitive_closure preexisting where preexisting.ancestor_id=#{parent_id} and preexisting.descendant_id=#{child_id})")
-        connection.execute("Insert into transitive_closure
-             select distinct parents_ancestors.ancestor_id, childs_descendants.descendant_id from
-              transitive_closure parents_ancestors,
-              transitive_closure childs_descendants
-             where
-              (parents_ancestors.descendant_id = #{parent_id} or parents_ancestors.ancestor_id = #{parent_id})
-              and (childs_descendants.ancestor_id = #{child_id} or childs_descendants.descendant_id = #{child_id})
-              and not exists (Select NULL from transitive_closure preexisting where preexisting.ancestor_id = parents_ancestors.ancestor_id
-                                                                           and preexisting.descendant_id = childs_descendants.descendant_id)")
+    class Assignment < ::ActiveRecord::Base
+      attr_accessible :child_id, :parent_id
+      # needs parent_id, child_id columns
+      belongs_to :parent, class_name: :PolicyElement
+      belongs_to :child, class_name: :PolicyElement
+
+      def self.transitive_closure?(ancestor, descendant)
+        descendants_of(ancestor).include?(descendant)
       end
 
-      def remove_from_transitive_closure
-        connection.execute('Lock transitive_closure in share row exclusive mode')
-        parents_ancestors = connection.execute("Select ancestor_id from transitive_closure where descendant_id=#{parent_id}")
-        childs_descendants = connection.execute("Select descendant_id from transitive_closure where ancestor_id=#{child_id}")
-        parents_ancestors = parents_ancestors.values.<<(parent_id).join(',')
-        childs_descendants = childs_descendants.values.<<(child_id).join(',')
-
-        connection.execute("Delete from transitive_closure where
-          ancestor_id in (#{parents_ancestors}) and
-          descendant_id in (#{childs_descendants}) and
-          not exists (Select NULL from assignments where parent_id=ancestor_id and child_id=descendant_id)
-        ")
-
-        connection.execute("Insert into transitive_closure
-            select distinct ancestors_surviving_relationships.ancestor_id, descendants_surviving_relationships.descendant_id
-            from
-              transitive_closure ancestors_surviving_relationships,
-              transitive_closure descendants_surviving_relationships
-            where
-              (ancestors_surviving_relationships.ancestor_id in (#{parents_ancestors}))
-              and (descendants_surviving_relationships.descendant_id in (#{childs_descendants}))
-              and (ancestors_surviving_relationships.descendant_id = descendants_surviving_relationships.ancestor_id)
-        ")
+      def self.descendants_of(element)
+        recursive_query = join_recursive do |query|
+          query.start_with(parent_id: element.id).connect_by(child_id: :parent_id)
+        end
+        PolicyElement.where(id: recursive_query.select('assignments.child_id'))
       end
+
+      def self.ancestors_of(element)
+        recursive_query = join_recursive do |query|
+          query.start_with(child_id: element.id).connect_by(parent_id: :child_id)
+        end
+        PolicyElement.where(id: recursive_query.select('assignments.parent_id'))
+      end
+
     end
   end
 end

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pg')
   s.add_development_dependency('database_cleaner')
   s.add_development_dependency('will_paginate', '~> 3.0.5')
+  s.add_development_dependency('activerecord-hierarchical_query', '~> 0.0')
 
 end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -101,7 +101,7 @@ describe 'ActiveRecord' do
 
       it 'does not have O(n) database calls' do
         #TODO: Find a way to count all database calls that doesn't conflict with ActiveRecord magic
-        PolicyMachineStorageAdapter::ActiveRecord::TransitiveClosure.should_receive(:exists?).at_most(10).times
+        PolicyMachineStorageAdapter::ActiveRecord::Assignment.should_receive(:transitive_closure?).at_most(10).times
         @pm.is_privilege?(@u1, @op, @objects.first).should be
       end
 


### PR DESCRIPTION
Refactors the active_record adapters to isolate transitive closure implementation and use tail recursive SQL in the postgres one. I cheated and used an existing gem to generate the recursive queries. Here's a sample one:

```SQL
SELECT "policy_elements".* FROM "policy_elements"  WHERE "policy_elements"."id" IN (SELECT assignments.child_id FROM "assignments" INNER JOIN (WITH RECURSIVE "assignments__recursive" AS ( SELECT "assignments"."id", "assignments"."child_id", "assignments"."parent_id" FROM "assignments"  WHERE "assignments"."parent_id" = 1 UNION ALL SELECT "assignments"."id", "assignments"."child_id", "assignments"."parent_id" FROM "assignments" INNER JOIN "assignments__recursive" ON "assignments__recursive"."child_id" = "assignments"."parent_id" ) SELECT "assignments__recursive".* FROM "assignments__recursive" ) AS "assignments__recursive" ON "assignments"."id" = "assignments__recursive"."id")
```

In the process, I fixed the mysql adapter, which had gotten mildly broken by removing `insert ignore`. Specs now pass for both mysql and postgres, with coverage the same as before.

No promises that this is actually efficient on reads.