### PR TITLE
Fix active_record has_and_belongs_to_many performance

### DIFF
--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -13,16 +13,20 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', '~> 3.2')
 
+  # Only required in ActiveRecord mode
+  s.add_dependency('activerecord-import', '~> 0.0')
+    # Only required for mysql
+    s.add_dependency('mysql2')
+    # Only required for postgres
+    s.add_dependency('pg')
+    s.add_dependency('activerecord-hierarchical_query', '~> 0.0')
+
   s.add_development_dependency('rspec', '~> 2.13.0')
   s.add_development_dependency('simplecov', '~> 0.7.1')
   s.add_development_dependency('debugger', '~> 1.6.0')
   s.add_development_dependency('neography', '~> 1.1')
   s.add_development_dependency('rails', '~> 3.2')
-  s.add_development_dependency('mysql2')
-  s.add_development_dependency('pg')
   s.add_development_dependency('database_cleaner')
   s.add_development_dependency('will_paginate', '~> 3.0.5')
-  s.add_development_dependency('activerecord-hierarchical_query', '~> 0.0')
-  s.add_development_dependency('activerecord-import', '~> 0.0')
 
 end

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('database_cleaner')
   s.add_development_dependency('will_paginate', '~> 3.0.5')
   s.add_development_dependency('activerecord-hierarchical_query', '~> 0.0')
+  s.add_development_dependency('activerecord-import', '~> 0.0')
 
 end


### PR DESCRIPTION
Betrayed! Betrayed by ActiveRecord!

If you have an operation set with three elements, and you change it to an operation set with 111 elements, the innocuous command `operations=` actually generates 108 inserts (and for some reason also 108 queries to table metadata). This does not appear to be something ActiveRecord can be talked out of doing. So I've overwritten the method to take the diff and convert it into (at most) two writes, a bulk delete and bulk insert.

I've been trying to keep raw SQL out of the main active_record adapter, so I brought in a gem that adds the `.import` method to ActiveRecord classes to do the bulk insert bit. Tests pass with both postgres and mysql.

Future plans include cleaning this (and the extra_attributes nonsense) up in the Postgres adapter using collection columns (hstore, array, iarray).