### PR TITLE
Document behavior when overwriting an existing association

### DIFF
--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -193,6 +193,16 @@ shared_examples "a policy machine" do
         policy_machine.add_association(@user_attribute, @operation_set, @object_attribute).should be_true
       end
 
+      it 'overwrites old associations between the same attributes' do
+        policy_machine.add_association(@user_attribute, Set.new([@operation1]), @object_attribute)
+
+        expect{policy_machine.add_association(@user_attribute, Set.new([@operation2]), @object_attribute)}
+          .to change{ policy_machine.scoped_privileges(@user_attribute, @object_attribute) }
+          .from( [[@user_attribute, @operation1, @object_attribute]] )
+          .to(   [[@user_attribute, @operation2, @object_attribute]] )
+
+      end
+
     end
   end
 


### PR DESCRIPTION
Blithely assured Yi that we had enough spec coverage for this, then decided he was right and I was wrong.

This spec passes, and should pass given we rely on this behavior, but it's not totally intuitive so I think it's worth having both as documentation and as a more thorough test for `operations=` that involves both adding and removing.

All specs pass for mysql, postgres, and in memory.