### PR TITLE
[MCC-168375] removes cycle checking for performance

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -15,14 +15,14 @@ module PolicyMachineStorageAdapter
 
       def self.descendants_of(element)
         recursive_query = join_recursive do |query|
-          query.start_with(parent_id: element.id).connect_by(child_id: :parent_id).nocycle
+          query.start_with(parent_id: element.id).connect_by(child_id: :parent_id)
         end
         PolicyElement.where(id: recursive_query.select('assignments.child_id'))
       end
 
       def self.ancestors_of(element)
         recursive_query = join_recursive do |query|
-          query.start_with(child_id: element.id).connect_by(parent_id: :child_id).nocycle
+          query.start_with(child_id: element.id).connect_by(parent_id: :child_id)
         end
         PolicyElement.where(id: recursive_query.select('assignments.parent_id'))
       end


### PR DESCRIPTION
- Remove .no_cycle method when recursively querying for decendants
- Yields ~10% performance increase based on benchmark tests

@yzhangmedidata @HonoreDB @csavage-mdsol 