### PR TITLE
Add global config for whether to tolerate cycles

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -223,6 +223,13 @@ class PolicyMachine
     policy_machine_storage_adapter.transaction(&block)
   end
 
+  # Global configuration options
+  # Supported:
+    # tolerate_cycles (boolean, defaults to false)
+  def self.config
+    @config ||= {}
+  end
+
   private
 
     # Raise unless the argument is a policy element.

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -370,6 +370,17 @@ shared_examples "a policy machine" do
       policy_machine.is_privilege?(@u1, @w, @o1).should be_false
     end
 
+    context 'tolerate_cycles is set to true' do
+      before { PolicyMachine.config[:tolerate_cycles] = true }
+      after  { PolicyMachine.config.clear }
+      it 'tolerates cycles when configured' do
+        @groupa = policy_machine.create_user_attribute('GroupA')
+        policy_machine.add_assignment(@groupa, @group1)
+        policy_machine.add_assignment(@group1, @groupa)
+        policy_machine.is_privilege?(@u1, @w, @o1).should be_true
+      end
+    end
+
     describe 'options' do
       describe 'associations' do
         it 'raises unless options[:associations] is an Array' do


### PR DESCRIPTION
@yzhangmedidata @agodel @drozenberg I hadn't bothered with this because I didn't see a use case, but it sounds like this could make a two-phased deployment significantly easier, so here it is if you want it.

Makes cycle tolerance globally configurable since our dependency structure makes configuring a specific adapter awkward. As it happens, it looks like all adapters other than Postgres tolerate cycles just fine (I'm not sure how neo4j is managing it, but it is).

Specs pass.