### PR TITLE
Add missing features to neography adapter

### DIFF
--- a/lib/policy_machine_storage_adapters/neography.rb
+++ b/lib/policy_machine_storage_adapters/neography.rb
@@ -4,15 +4,15 @@ rescue LoadError
   neography_unavailable = true
 end
 
-# This class stores policy elements in a neo4j graph db using the neography client and 
+# This class stores policy elements in a neo4j graph db using the neography client and
 # exposes required operations for managing/querying these elements.
 # Note that this adapter shouldn't be used in production for high-performance needs as Neography
 # is inherently slower than more direct NEO4J access.
 module PolicyMachineStorageAdapter
   class Neography
-    
+
     POLICY_ELEMENT_TYPES = %w(user user_attribute object object_attribute operation policy_class)
-    
+
     POLICY_ELEMENT_TYPES.each do |pe_type|
       ##
       # Store a policy element of type pe_type.
@@ -34,31 +34,32 @@ module PolicyMachineStorageAdapter
         persisted_pe.add_to_index('policy_element_types', 'pe_type', pe_type)
         persisted_pe
       end
-      
+
       define_method("find_all_of_type_#{pe_type}") do |options = {}|
         found_elts = ::Neography::Node.find('policy_element_types', 'pe_type', pe_type)
         found_elts = found_elts.nil? ? [] : [found_elts].flatten
         found_elts.select do |elt|
-          options.all? do |k,v|
+          options.except(:ignore_case).all? do |k,v|
             if v.nil?
               !elt.respond_to?(k)
             else
-              elt.respond_to?(k) && elt.send(k) == v
+              elt.respond_to?(k) &&
+                ((elt.send(k).is_a?(String) && v.is_a?(String) && ignore_case_applies?(options[:ignore_case], k)) ? elt.send(k).downcase == v.downcase : elt.send(k) == v)
             end
           end
         end
       end
     end
-    
+
     ##
     # Assign src to dst in policy machine
     #
     def assign(src, dst)
       assert_persisted_policy_element(src)
       assert_persisted_policy_element(dst)
-      
+
       e = ::Neography::Relationship.create(:outgoing, src, dst)
-      
+
       if e.nil?
         false
       else
@@ -67,30 +68,35 @@ module PolicyMachineStorageAdapter
         true
       end
     end
-    
+
+    # Allow ignore_case to be a boolean, string, symbol, or array of symbols or strings
+    def ignore_case_applies?(ignore_case, key)
+      ignore_case == true || ignore_case.to_s == key || ( ignore_case.respond_to?(:any?) && ignore_case.any?{ |k| k.to_s == key.to_s} )
+    end
+
     ##
     # Determine if there is a path from src to dst in the policy machine
     #
     def connected?(src, dst)
       assert_persisted_policy_element(src)
       assert_persisted_policy_element(dst)
-      
+
       return true if src == dst
-      
-      neo_connection.execute_query("start n=node({id1}),m=node({id2}) return (n)-[*]->(m)", 
+
+      neo_connection.execute_query("start n=node({id1}),m=node({id2}) return (n)-[*]->(m)",
         {:id1 => src.neo_id.to_i, :id2 => dst.neo_id.to_i})['data'] != [[[]]]
     end
 
     ##
     # Disconnect two policy elements in the machine
-    #    
+    #
     def unassign(src, dst)
       assert_persisted_policy_element(src)
       assert_persisted_policy_element(dst)
-      
+
       unique_identifier = src.unique_identifier + dst.unique_identifier
       found_edges = ::Neography::Relationship.find('edges', 'unique_identifier', unique_identifier)
-      
+
       if found_edges
         # Neography::Relationship doesn't respond to .to_a
         found_edges = [found_edges] unless found_edges.is_a?(Array)
@@ -121,23 +127,24 @@ module PolicyMachineStorageAdapter
     # Update a persisted policy element
     #
     def update(element, changes_hash)
+      changes_hash.each { |k,v| element.public_send("#{k}=",v)}
       element.neo_server.set_node_properties(element.neo_id, changes_hash)
     end
 
-    
+
     ##
     # Determine if the given node is in the policy machine or not.
     def element_in_machine?(pe)
       found_node = ::Neography::Node.find('nodes', 'unique_identifier', pe.unique_identifier)
       !found_node.nil?
     end
-    
+
     ##
     # Add the given association to the policy map.  If an association between user_attribute
     # and object_attribute already exists, then replace it with that given in the arguments.
     def add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
       remove_association(user_attribute, object_attribute, policy_machine_uuid)
-      
+
       # TODO:  scope by policy machine uuid
       unique_identifier = user_attribute.unique_identifier + object_attribute.unique_identifier
       node_attrs = {
@@ -149,14 +156,14 @@ module PolicyMachineStorageAdapter
       }
       persisted_assoc = ::Neography::Node.create(node_attrs)
       persisted_assoc.add_to_index('associations', 'unique_identifier', unique_identifier)
-      
+
       [user_attribute, object_attribute, *operation_set].each do |element|
         ::Neography::Relationship.create(:in_association, element, persisted_assoc)
       end
 
       true
     end
-    
+
     ##
     # Return all associations in which the given operation is included
     # Returns an array of arrays.  Each sub-array is of the form
@@ -166,23 +173,23 @@ module PolicyMachineStorageAdapter
       operation.outgoing(:in_association).map do |association|
         user_attribute = ::Neography::Node.find('nodes', 'unique_identifier', association.user_attribute_unique_identifier)
         object_attribute = ::Neography::Node.find('nodes', 'unique_identifier', association.object_attribute_unique_identifier)
-        
+
         operation_set = Set.new
         JSON.parse(association.operations).each do |op_unique_id|
           op_node = ::Neography::Node.find('nodes', 'unique_identifier', op_unique_id)
           operation_set << op_node
         end
-        
+
         [user_attribute, operation_set, object_attribute]
-      end      
+      end
     end
-    
+
     ##
-    # Remove an existing association.  Return true if the association was removed and false if 
+    # Remove an existing association.  Return true if the association was removed and false if
     # it didn't exist in the first place.
     def remove_association(user_attribute, object_attribute, policy_machine_uuid)
       unique_identifier = user_attribute.unique_identifier + object_attribute.unique_identifier
-      
+
       begin
         assoc_node = ::Neography::Node.find('associations', 'unique_identifier', unique_identifier)
         return false unless assoc_node
@@ -192,7 +199,7 @@ module PolicyMachineStorageAdapter
         false
       end
     end
-    
+
     ##
     # Return array of all policy classes which contain the given object_attribute (or object).
     # Return empty array if no such policy classes found.
@@ -220,14 +227,14 @@ module PolicyMachineStorageAdapter
     end
 
     private
-    
+
       # Raise argument error if argument is not suitable for consumption in
       # public methods.
       def assert_persisted_policy_element(arg)
         raise(ArgumentError, "arg must be a Neography::Node; got #{arg.class.name}") unless arg.is_a?(::Neography::Node)
         raise(ArgumentError, "arg must be persisted") unless element_in_machine?(arg)
       end
-      
+
       # Neo4j client
       def neo_connection
         @neo_connection ||= ::Neography::Rest.new


### PR DESCRIPTION
Irritation-driven development--I want to run `rspec` and have it actually pass on all adapters, even the silly ones. This does that.

```
Finished in 1 minute 22.06 seconds
815 examples, 0 failures, 4 pending
Warning: coverage data provided by Coverage [244] exceeds number of lines in /Users/aweiner/the_policy_machine/lib/policy_machine_storage_adapters/neography.rb [243]
Coverage report generated for RSpec to /Users/aweiner/the_policy_machine/coverage. 710 / 714 LOC (99.44%) covered.
```