### PR TITLE
fixes maudit-client bug by defining methods only on PE and not base

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -74,7 +74,7 @@ module PolicyMachineStorageAdapter
       # Uses ActiveRecord's store method to methodize new attribute keys in extra_attributes
       def store_attributes
         @extra_attributes_hash = ExtraAttributesHash[self.extra_attributes.is_a?(Hash) ? self.extra_attributes : JSON.parse(self.extra_attributes, quirks_mode: true)]
-        ::ActiveRecord::Base.store_accessor(:extra_attributes, @extra_attributes_hash.keys)
+        self.class.store_accessor(:extra_attributes, @extra_attributes_hash.keys)
       end
 
       def descendants


### PR DESCRIPTION
The purpose of this PR is to fix a bug cause by this line. Without this change, if there is any attribute stored in "extra_attributes" that shares the name of an attribute on another model in the application that inherits directly from ActiveRecord::Base, that model will expect that attribute to be stored in "extra_attributes" as well because of this. Targeting the method at PolicyElement fixes this.

@mdsol/team04 @csavage-mdsol @DMcKinnon-mdsol 