### PR TITLE
adds ability to pass a custom where clause to the storage adapter if it is an active record db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.3
+
+* Adds functionality for custom where clauses using activerecord storage adapter
+
 # 0.0.2
 
 * Fix: Operation sets now silently remove duplicates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ If you want to contribute an enhancement or a fix:
 First cd into the test/dummy directory and create the test db with:
 
 ```
-bundle exec rake db:create
-bundle exec rake db:migrate
-bundle exec rake db:test:prepare
+[bundle exec] rake db:create
+[bundle exec] rake db:migrate
+[bundle exec] rake db:test:prepare
 ```
 
 Run all rspec with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,14 @@ If you want to contribute an enhancement or a fix:
 
 ## Running Automated Tests
 
+First cd into the test/dummy directory and create the test db with
+
+```
+bundle exec rake db:create
+bundle exec rake db:migrate
+bundle exec rake db:test:prepare
+```
+
 Run all rspec with:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If you want to contribute an enhancement or a fix:
 
 ## Running Automated Tests
 
-First cd into the test/dummy directory and create the test db with
+First cd into the test/dummy directory and create the test db with:
 
 ```
 bundle exec rake db:create

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -165,7 +165,7 @@ module PolicyMachineStorageAdapter
           if options[:ignore_case]
             match_expressions = conditions.map {|k,v| ignore_case_applies?(options[:ignore_case],k) ?
               pe_class.arel_table[k].matches(v) : pe_class.arel_table[k].eq(v) }
-            match_expressions.inject(pe_class.scoped) {|rel, e| rel.where(e)}
+            match_expressions.inject(pe_class.scoped) {|rel, e| rel.where(e)}.where(custom_where_clause)
           else
             pe_class.where(conditions).where(custom_where_clause)
           end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -156,10 +156,10 @@ module PolicyMachineStorageAdapter
       end
 
       define_method("find_all_of_type_#{pe_type}") do |options = {}|
+        custom_where_clause = options.delete(:where) || ""
         conditions = options.slice!(:per_page, :page, :ignore_case).stringify_keys
         extra_attribute_conditions = conditions.slice!(*PolicyElement.column_names)
         pe_class = class_for_type(pe_type)
-
         # Arel matches provides agnostic case insensitive sql for mysql and postgres
         all = begin
           if options[:ignore_case]
@@ -167,7 +167,7 @@ module PolicyMachineStorageAdapter
               pe_class.arel_table[k].matches(v) : pe_class.arel_table[k].eq(v) }
             match_expressions.inject(pe_class.scoped) {|rel, e| rel.where(e)}
           else
-            pe_class.where(conditions)
+            pe_class.where(conditions).where(custom_where_clause)
           end
         end
 

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -28,6 +28,10 @@ module PolicyMachineStorageAdapter
       # The results are paginated via will_paginate using the pagination params in the params hash
       # The find is case insensitive to the conditions
       define_method("find_all_of_type_#{pe_type}") do |options = {}|
+        if options.delete(:where)
+          raise NotImplementedError.new('you are trying to use an active_record where clause on an in memory storage adapter!')
+        end
+
         conditions = options.slice!(:per_page, :page, :ignore_case).merge(pe_type: pe_type)
         elements = policy_elements.select do |pe|
           conditions.all? do |k,v|

--- a/lib/policy_machine_storage_adapters/neography.rb
+++ b/lib/policy_machine_storage_adapters/neography.rb
@@ -36,6 +36,9 @@ module PolicyMachineStorageAdapter
       end
       
       define_method("find_all_of_type_#{pe_type}") do |options = {}|
+        if options.delete(:where)
+          raise NotImplementedError.new('you are trying to use an active_record where clause on an in memory storage adapter!')
+        end
         found_elts = ::Neography::Node.find('policy_element_types', 'pe_type', pe_type)
         found_elts = found_elts.nil? ? [] : [found_elts].flatten
         found_elts.select do |elt|

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "policy_machine"
-  s.version     = "0.0.2"
+  s.version     = "0.0.3"
   s.summary     = "Policy Machine!"
   s.description = "A ruby implementation of the Policy Machine authorization formalism."
   s.authors     = ['Matthew Szenher', 'Aaron Weiner']

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -40,6 +40,13 @@ describe 'ActiveRecord' do
           policy_machine_storage_adapter.find_all_of_type_object(color: 'blue').map(&:color).should eql(['blue'])
         end
 
+        it 'uses a custom where clause when the where key is present' do
+          policy_machine_storage_adapter.add_object('some_uuid1', 'some_policy_machine_uuid1')
+          policy_machine_storage_adapter.add_object('some_uuid2', 'some_policy_machine_uuid1', color: 'red')
+          policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1', color: 'blue')
+          policy_machine_storage_adapter.find_all_of_type_object(where: "unique_identifier LIKE '%uuid1'").should be_one
+        end
+
         context 'pagination' do
           before do
             10.times {|i| policy_machine_storage_adapter.add_object("uuid_#{i}", 'some_policy_machine_uuid1', color: 'red') }

--- a/spec/policy_machine_storage_adapters/in_memory_spec.rb
+++ b/spec/policy_machine_storage_adapters/in_memory_spec.rb
@@ -31,6 +31,10 @@ describe PolicyMachineStorageAdapter::InMemory do
         results.first.unique_identifier.should == "uuid_0"
         results.last.unique_identifier.should == "uuid_2"
       end
+
+      it 'raises if you try to inject a where clause' do
+        expect { policy_machine_storage_adapter.find_all_of_type_object(where: 'custom_query') }.to raise_error
+      end
     end
   end
 end

--- a/spec/policy_machine_storage_adapters/neography_spec.rb
+++ b/spec/policy_machine_storage_adapters/neography_spec.rb
@@ -34,6 +34,13 @@ describe 'Neography' do
         policy_machine_storage_adapter.assign(src, dst).should be_false
       end
     end
+
+    describe 'find all' do
+      it 'raises a NotImplementedError when active_record statements are added' do
+        policy_machine_storage_adapter = PolicyMachineStorageAdapter::Neography.new
+        expect { policy_machine_storage_adapter.find_all_of_type_object(where: "unique_identifier LIKE '%uuid1'") }.to raise_error
+      end
+    end
   end
 end if neo4j_exists?
 


### PR DESCRIPTION
The purpose of this PR is to support custom where clauses for the active_record storage adapter. If we pass :where to the find all method, it will insert a where clause with the value passed"

@mdsol/team04 

This is necessary functionality for nested config type roles to be performant in Dalton