### PR TITLE
Add accessible objects list per user and operation

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -69,7 +69,7 @@ class PolicyMachine
   # TODO: Parallelize the two component checks
   def is_privilege?(user_or_attribute, operation, object_or_attribute, options = {})
     is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options) &&
-      !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)
+      (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
   end
 
   ##
@@ -191,6 +191,21 @@ class PolicyMachine
     else
       prohibited_operations = prohibitions.map { |_,prohibition,_| prohibition.operation }
       privileges.reject { |_,op,_| prohibited_operations.include?(op.unique_identifier) }
+    end
+  end
+
+  ##
+  # Returns an array of all objects the given user (attribute)
+  # has the given operation on.
+  def accessible_objects(user_or_attribute, operation, options = {})
+    if policy_machine_storage_adapter.respond_to?(:accessible_objects)
+      policy_machine_storage_adapter.accessible_objects(user_or_attribute, operation, options)
+    else
+      result = objects.select { |object| is_privilege?(user_or_attribute, operation, object, options) }
+      if inclusion = options[:includes]
+        result.select! { |object| object.unique_identifier.include?(inclusion) }
+      end
+      result
     end
   end
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -12,16 +12,16 @@ module PolicyMachineStorageAdapter
         descendants_of(ancestor).include?(descendant)
       end
 
-      def self.descendants_of(element)
+      def self.descendants_of(element_or_scope)
         recursive_query = join_recursive do |query|
-          query.start_with(parent_id: element.id).connect_by(child_id: :parent_id).nocycle
+          query.start_with(parent_id: element_or_scope).connect_by(child_id: :parent_id).nocycle
         end
         PolicyElement.where(id: recursive_query.select('assignments.child_id'))
       end
 
-      def self.ancestors_of(element)
+      def self.ancestors_of(element_or_scope)
         recursive_query = join_recursive do |query|
-          query.start_with(child_id: element.id).connect_by(parent_id: :child_id).nocycle
+          query.start_with(child_id: element_or_scope).connect_by(parent_id: :child_id).nocycle
         end
         PolicyElement.where(id: recursive_query.select('assignments.parent_id'))
       end

--- a/lib/policy_machine_storage_adapters/template.rb
+++ b/lib/policy_machine_storage_adapters/template.rb
@@ -173,5 +173,11 @@ module PolicyMachineStorageAdapter
 
     end
 
+    # Optimized version of PolicyMachine#accessible_objects
+    # Return all objects the user has the given operation on
+    # Optional: only add this method if you can do it better than policy_machine.rb
+    def accessible_objects(user_or_attribute, operation, options = {})
+    end
+
   end
 end


### PR DESCRIPTION
Adds PolicyMachine#accessible_objects method, using the same "slow default implementation, fast(ish) implementation in the activerecord adapter"). 

The mysql adapter seems to have been broken by the Rails update, so I wasn't able to add it to this. It should be a simple change, though. I'll fix mysql in a separate PR.

I haven't performance tested this yet, but if I end up optimizing it further I don't think it'll change the API, which is just `policy_machine.accessible_objects(user_or_user_attribute, operation, [includes: substring], [ignore_prohibitions: true])` returning an array of internal representations of objects.

Specs:

Finished in 2 minutes 18.76 seconds
931 examples, 0 failures, 22 pending
Coverage report generated for RSpec to /Users/aweiner/the_policy_machine/coverage. 776 / 780 LOC (99.49%) covered.