### PR TITLE
allow passing in column name to seach by as key

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -144,7 +144,7 @@ class PolicyMachine
     end
   end
 
-  
+
 
   ##
   # Returns an array of all privileges encoded in this

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -356,8 +356,8 @@ module PolicyMachineStorageAdapter
       direct_scope = permitting_oas.where(type: class_for_type('object'))
       indirect_scope = Assignment.ancestors_of(permitting_oas).where(type: class_for_type('object'))
       if inclusion = options[:includes]
-        direct_scope = Adapter.apply_include_condition(scope: direct_scope, key: :unique_identifier, value: inclusion, klass: class_for_type('object'))
-        indirect_scope = Adapter.apply_include_condition(scope: indirect_scope, key: :unique_identifier, value: inclusion, klass: class_for_type('object'))
+        direct_scope = Adapter.apply_include_condition(scope: direct_scope, key: options[:key], value: inclusion, klass: class_for_type('object'))
+        indirect_scope = Adapter.apply_include_condition(scope: indirect_scope, key: options[:key], value: inclusion, klass: class_for_type('object'))
       end
       candidates = direct_scope | indirect_scope
       if options[:ignore_prohibitions] || !(prohibition = class_for_type('operation').find_by_unique_identifier("~#{operation.unique_identifier}"))

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -301,7 +301,7 @@ shared_examples "a policy machine" do
         @u.foo.should == 'baz'
         policy_machine.users.last.foo.should == 'baz'
       end
-      
+
       it 'updates persisted extra attributes with new keys' do
         @u = policy_machine.create_user('u1', foo: 'bar')
         @u.update(foo: 'baz', bla: 'bar')
@@ -792,13 +792,13 @@ shared_examples "a policy machine" do
     end
 
     it 'lists all objects with the given privilege for the given user' do
-      expect( policy_machine.accessible_objects(@u1, @read).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
-      expect( policy_machine.accessible_objects(@u1, @write).map(&:unique_identifier) ).to eq( ['red:one'] )
+      expect( policy_machine.accessible_objects(@u1, @read, key: :unique_identifier).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
+      expect( policy_machine.accessible_objects(@u1, @write, key: :unique_identifier).map(&:unique_identifier) ).to eq( ['red:one'] )
     end
 
     it 'filters objects via substring matching' do
-      expect( policy_machine.accessible_objects(@u1, @read, includes: 'fish').map(&:unique_identifier) ).to match_array(['one:fish','two:fish'])
-      expect( policy_machine.accessible_objects(@u1, @read, includes: 'one').map(&:unique_identifier) ).to match_array(['one:fish','red:one'])
+      expect( policy_machine.accessible_objects(@u1, @read, includes: 'fish', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['one:fish','two:fish'])
+      expect( policy_machine.accessible_objects(@u1, @read, includes: 'one', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['one:fish','red:one'])
     end
 
     context 'with prohibitions' do


### PR DESCRIPTION
This PR allows PM users to pass in the column name that is to be searched for the purpose of deriving bulk permissions.