### PR TITLE
Break recursive queries into multiple calls to avoid confusing the optimizer

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -13,19 +13,32 @@ module PolicyMachineStorageAdapter
       end
 
       def self.descendants_of(element_or_scope)
-        element_or_scope = element_or_scope.to_a if element_or_scope.respond_to?(:to_a)
-        recursive_query = join_recursive do |query|
-          query.start_with(parent_id: element_or_scope).connect_by(child_id: :parent_id)
+        #FIXME: Preloading with to_a seems to be necessary because putting complex sql in start_with can
+        # lead to degenerate performance (noticed in ancestors_of call in accessible_objects)
+        # Ideally, fix the SQL so it's both a single call and performant
+        element_or_scope = [*element_or_scope]
+        case element_or_scope.size
+        when 0
+          PolicyElement.none
+        when 1
+          PolicyElement.where('"policy_elements"."id" IN (SELECT assignments__recursive.child_id FROM (WITH RECURSIVE "assignments__recursive" AS ( SELECT "assignments"."id", "assignments"."child_id", "assignments"."parent_id" FROM "assignments" WHERE "assignments"."parent_id" = ? UNION ALL SELECT "assignments"."id", "assignments"."child_id", "assignments"."parent_id" FROM "assignments" INNER JOIN "assignments__recursive" ON "assignments__recursive"."child_id" = "assignments"."parent_id" ) SELECT "assignments__recursive".* FROM "assignments__recursive") AS "assignments__recursive")', element_or_scope.first.id)
+        else
+          PolicyElement.where('"policy_elements"."id" IN (SELECT assignments__recursive.child_id FROM (WITH RECURSIVE "assignments__recursive" AS ( SELECT "assignments"."id", "assignments"."child_id", "assignments"."parent_id" FROM "assignments" WHERE "assignments"."parent_id" in (?) UNION ALL SELECT "assignments"."id", "assignments"."child_id", "assignments"."parent_id" FROM "assignments" INNER JOIN "assignments__recursive" ON "assignments__recursive"."child_id" = "assignments"."parent_id" ) SELECT "assignments__recursive".* FROM "assignments__recursive") AS "assignments__recursive")', element_or_scope.map(&:id))
         end
-        PolicyElement.where(id: recursive_query.select('assignments__recursive.child_id'))
       end
 
       def self.ancestors_of(element_or_scope)
-        element_or_scope = element_or_scope.to_a if element_or_scope.respond_to?(:to_a)
-        recursive_query = join_recursive do |query|
-          query.start_with(child_id: element_or_scope).connect_by(parent_id: :child_id)
+        #FIXME: Also, removing the superfluous join of Assignment onto the recursive call is hugely beneficial to performance, but not supported
+        # by hierarchical_query. Since this is a major performance pain point, generating raw SQL for now.
+        element_or_scope = [*element_or_scope]
+        case element_or_scope.size
+        when 0
+          PolicyElement.none
+        when 1
+          PolicyElement.where('"policy_elements"."id" IN (SELECT assignments__recursive.parent_id FROM (WITH RECURSIVE "assignments__recursive" AS ( SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" WHERE "assignments"."child_id" = ? UNION ALL SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" INNER JOIN "assignments__recursive" ON "assignments__recursive"."parent_id" = "assignments"."child_id" ) SELECT "assignments__recursive".* FROM "assignments__recursive") AS "assignments__recursive")', element_or_scope.first.id)
+        else
+          PolicyElement.where('"policy_elements"."id" IN (SELECT assignments__recursive.parent_id FROM (WITH RECURSIVE "assignments__recursive" AS ( SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" WHERE "assignments"."child_id" in (?) UNION ALL SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" INNER JOIN "assignments__recursive" ON "assignments__recursive"."parent_id" = "assignments"."child_id" ) SELECT "assignments__recursive".* FROM "assignments__recursive") AS "assignments__recursive")', element_or_scope.map(&:id))
         end
-        PolicyElement.where(id: recursive_query.select('assignments__recursive.parent_id'))
       end
 
     end

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -13,17 +13,19 @@ module PolicyMachineStorageAdapter
       end
 
       def self.descendants_of(element_or_scope)
+        element_or_scope = element_or_scope.to_a if element_or_scope.respond_to?(:to_a)
         recursive_query = join_recursive do |query|
-          query.start_with(parent_id: element_or_scope).connect_by(child_id: :parent_id).nocycle
+          query.start_with(parent_id: element_or_scope).connect_by(child_id: :parent_id)
         end
-        PolicyElement.where(id: recursive_query.select('assignments.child_id'))
+        PolicyElement.where(id: recursive_query.select('assignments__recursive.child_id'))
       end
 
       def self.ancestors_of(element_or_scope)
+        element_or_scope = element_or_scope.to_a if element_or_scope.respond_to?(:to_a)
         recursive_query = join_recursive do |query|
-          query.start_with(child_id: element_or_scope).connect_by(parent_id: :child_id).nocycle
+          query.start_with(child_id: element_or_scope).connect_by(parent_id: :child_id)
         end
-        PolicyElement.where(id: recursive_query.select('assignments.parent_id'))
+        PolicyElement.where(id: recursive_query.select('assignments__recursive.parent_id'))
       end
 
     end


### PR DESCRIPTION
Not quite ready to call this done, there's lots more savings to get by removing the unnecessary join of Assignment onto the result, and also I don't understand how or why any of this works, but it reduces a 30-second call to a second and a half on sandbox so I'm getting it out there for posterity. The SQL this generates is 
```sql
SELECT "policy_elements".* FROM "policy_elements" WHERE "policy_elements"."id" IN (SELECT assignments__recursive.parent_id FROM "assignments" INNER JOIN (WITH RECURSIVE "assignments__recursive" AS ( SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" WHERE "assignments"."child_id" IN (1876421, 1876537, 1879376, 1878545, 1876592, 1876647, 1878453, 1878913, 1879042, 1879211, 1879432, 1879318, 1879317, 1876423, 1879096, 1876648, 1878914, 1879377, 1879097, 1878454, 1876593, 1879043, 1879212, 1879431, 1878544, 1876536) UNION ALL SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" INNER JOIN "assignments__recursive" ON "assignments__recursive"."parent_id" = "assignments"."child_id" ) SELECT "assignments__recursive".* FROM "assignments__recursive") AS "assignments__recursive" ON "assignments"."id" = "assignments__recursive"."id") AND "policy_elements"."type" = 'PolicyMachineStorageAdapter::ActiveRecord::Object'
```

The SQL I wish it generated because it's much faster is

```SQL
SELECT "policy_elements".* FROM "policy_elements" WHERE "policy_elements"."id" IN (SELECT assignments__recursive.parent_id FROM (WITH RECURSIVE "assignments__recursive" AS ( SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" WHERE "assignments"."child_id" IN (1876421, 1876537, 1879376, 1878545, 1876592, 1876647, 1878453, 1878913, 1879042, 1879211, 1879432, 1879318, 1879317, 1876423, 1879096, 1876648, 1878914, 1879377, 1879097, 1878454, 1876593, 1879043, 1879212, 1879431, 1878544, 1876536) UNION ALL SELECT "assignments"."id", "assignments"."parent_id", "assignments"."child_id" FROM "assignments" INNER JOIN "assignments__recursive" ON "assignments__recursive"."parent_id" = "assignments"."child_id" ) SELECT "assignments__recursive".* FROM "assignments__recursive") AS "assignments__recursive") AND "policy_elements"."type" = 'PolicyMachineStorageAdapter::ActiveRecord::Object';
```

which should be equivalent, but it'll take more work to verify it actually is and to persuade ActiveRecord to generate it.