### PR TITLE
Dry up some code

### DIFF
--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -11,8 +11,7 @@ module PM
     attr_accessor   :extra_attributes
     attr_reader     :pm_storage_adapter
 
-    ##
-    # Create a new policy element with the given name and type.
+    # Creates a new policy element with the given name and type.
     def initialize(unique_identifier, policy_machine_uuid, pm_storage_adapter, stored_pe = nil, extra_attributes = {})
       @unique_identifier = unique_identifier.to_s
       @policy_machine_uuid = policy_machine_uuid.to_s
@@ -21,16 +20,13 @@ module PM
       @extra_attributes = extra_attributes
     end
 
-    ##
-    # Determine if self is connected to other node
+    # Determines if self is connected to other node
     def connected?(other_pe)
       @pm_storage_adapter.connected?(self.stored_pe, other_pe.stored_pe)
     end
 
-    ##
-    # Assign self to destination policy element
+    # Assigns self to destination policy element
     # This method is sensitive to the type of self and dst_policy_element
-    #
     def assign_to(dst_policy_element)
       unless allowed_assignee_classes.any?{|aac| dst_policy_element.is_a?(aac)}
         raise(ArgumentError, "expected dst_policy_element to be one of #{allowed_assignee_classes.to_s}; got #{dst_policy_element.class} instead.")
@@ -38,18 +34,14 @@ module PM
       @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)
     end
 
-    ##
-    # Remove assignment from self to destination policy element
+    # Removes assignment from self to destination policy element
     # Returns boolean indicating whether assignment was successfully removed.
-    #
     def unassign(dst_policy_element)
       @pm_storage_adapter.unassign(self.stored_pe, dst_policy_element.stored_pe)
     end
 
-    ##
-    # Remove self, and any assignments to or from self. Does not remove any other elements.
+    # Removes self and any assignments to or from self. Does not remove any other elements.
     # Returns true if persisted object was successfully removed.
-    #
     def delete
       if self.stored_pe && self.stored_pe.persisted
         @pm_storage_adapter.delete(stored_pe)
@@ -58,10 +50,8 @@ module PM
       end
     end
 
-    ##
     # Updates extra attributes with the passed-in values. Will not remove other
     # attributes not in the hash. Returns true if no errors occurred.
-    #
     def update(attr_hash)
       @extra_attributes.merge!(attr_hash)
       if self.stored_pe && self.stored_pe.persisted
@@ -70,8 +60,7 @@ module PM
       end
     end
 
-    ##
-    # Convert a stored_pe to an instantiated pe
+    # Converts a stored_pe to an instantiated pe
     def self.convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, pe_class)
       pe_class.new(
         stored_pe.unique_identifier,
@@ -81,18 +70,14 @@ module PM
       )
     end
 
-    ##
     # Returns true if self is identical to other and false otherwise.
-    #
     def ==(other_pe)
       self.class == other_pe.class &&
       self.unique_identifier == other_pe.unique_identifier &&
       self.policy_machine_uuid == other_pe.policy_machine_uuid
     end
 
-    ##
-    # Delegate extra attribute reads to stored_pe
-    #
+    # Delegates extra attribute reads to stored_pe
     def method_missing(meth, *args)
       if args.none? && stored_pe.respond_to?(meth)
         stored_pe.send(meth)
@@ -110,37 +95,37 @@ module PM
     end
 
     protected
-      def allowed_assignee_classes
-        raise "Must override this method in a subclass"
-      end
-  end
 
-  # TODO:  there is repeated code in the following subclasses which I will DRY in the
-  # next PR.
-  # A user in a policy machine.
-  class User < PolicyElement
+    def allowed_assignee_classes
+      raise "Must override this method in a subclass"
+    end
+
     def self.create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
       new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
-      new_pe.stored_pe = pm_storage_adapter.add_user(unique_identifier, policy_machine_uuid, extra_attributes)
+      method_name = "add_#{self.name.split('::').last}".underscore.to_sym
+      new_pe.stored_pe = pm_storage_adapter.send(method_name, unique_identifier, policy_machine_uuid, extra_attributes)
       new_pe
     end
 
+    # Returns all policy elements of a particular type (e.g. all users)
+    # TODO: Move all overrides of self.all to the base class
+    def self.all(pm_storage_adapter, options = {})
+      method_name = "find_all_of_type_#{self.name.split('::').last}".underscore.to_sym
+      result = pm_storage_adapter.send(method_name, options)
+      all_result = result.map do |stored_pe|
+        convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, self)
+      end
+      all_result.define_singleton_method(:total_entries) { result.total_entries }
+      all_result
+    end
+  end
+
+  # A user in a policy machine.
+  class User < PolicyElement
     def user_attributes(pm_storage_adapter)
       pm_storage_adapter.user_attributes_for_user(stored_pe).map do |stored_ua|
         self.class.convert_stored_pe_to_pe(stored_ua, pm_storage_adapter, PM::UserAttribute)
       end
-    end
-
-    # Return all policy elements of a particular type (e.g. all users)
-    # TODO: Move all overrides of self.all to the base class
-    def self.all(pm_storage_adapter, options = {})
-      result = pm_storage_adapter.find_all_of_type_user(options)
-      all_result = result.map do |stored_pe|
-        convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::User)
-      end
-      all_result.define_singleton_method(:total_entries) {result.total_entries}
-      all_result
-
     end
 
     protected
@@ -151,21 +136,6 @@ module PM
 
   # A user attribute in a policy machine.
   class UserAttribute < PolicyElement
-    def self.create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
-      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
-      new_pe.stored_pe = pm_storage_adapter.add_user_attribute(unique_identifier, policy_machine_uuid, extra_attributes)
-      new_pe
-    end
-
-     # Return all policy elements of a particular type (e.g. all users)
-    def self.all(pm_storage_adapter, options = {})
-      result = pm_storage_adapter.find_all_of_type_user_attribute(options)
-      all_result = result.map do |stored_pe|
-        convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::UserAttribute)
-      end
-      all_result.define_singleton_method(:total_entries) {result.total_entries}
-      all_result
-    end
 
     protected
     def allowed_assignee_classes
@@ -175,12 +145,6 @@ module PM
 
   # An object attribute in a policy machine.
   class ObjectAttribute < PolicyElement
-    def self.create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
-      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
-      new_pe.stored_pe = pm_storage_adapter.add_object_attribute(unique_identifier, policy_machine_uuid, extra_attributes)
-      new_pe
-    end
-
     # Returns an array of policy classes in which this ObjectAttribute is included.
     # Returns empty array if this ObjectAttribute is associated with no policy classes.
     def policy_classes
@@ -188,16 +152,6 @@ module PM
       pcs_for_object.map do |stored_pc|
         self.class.convert_stored_pe_to_pe(stored_pc, @pm_storage_adapter, PM::PolicyClass)
       end
-    end
-
-    def self.all(pm_storage_adapter, options = {})
-      result = pm_storage_adapter.find_all_of_type_object_attribute(options)
-      all_result = result.map do |stored_pe|
-        convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::ObjectAttribute)
-      end
-      all_result.define_singleton_method(:total_entries) {result.total_entries}
-      all_result
-
     end
 
     protected
@@ -208,22 +162,6 @@ module PM
 
   # An object in a policy machine.
   class Object < ObjectAttribute
-    def self.create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
-      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
-      new_pe.stored_pe = pm_storage_adapter.add_object(unique_identifier, policy_machine_uuid, extra_attributes)
-      new_pe
-    end
-
-    # Return all policy elements of a particular type (e.g. all users)
-    def self.all(pm_storage_adapter, options = {})
-      result = pm_storage_adapter.find_all_of_type_object(options)
-      all_result = result.map do |stored_pe|
-        convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::Object)
-      end
-      all_result.define_singleton_method(:total_entries) {result.total_entries}
-      all_result
-
-    end
 
     protected
     def allowed_assignee_classes
@@ -251,17 +189,6 @@ module PM
       end
     end
 
-    # Return all policy elements of a particular type (e.g. all users)
-    def self.all(pm_storage_adapter, options = {})
-      result = pm_storage_adapter.find_all_of_type_operation(options)
-      all_result = result.map do |stored_pe|
-        convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, PM::Operation)
-      end
-      all_result.define_singleton_method(:total_entries) {result.total_entries}
-      all_result
-
-    end
-
     def to_s
       unique_identifier
     end
@@ -280,7 +207,6 @@ module PM
 
     # Return all associations in which this Operation is included
     # Associations are arrays of PM::Attributes.
-    #
     def associations
       @pm_storage_adapter.associations_with(self.stored_pe).map do |assoc|
         PM::Association.new(assoc[0], assoc[1], assoc[2], @pm_storage_adapter)
@@ -312,12 +238,6 @@ module PM
 
   # A policy class in a policy machine.
   class PolicyClass < PolicyElement
-    def self.create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
-      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
-      new_pe.stored_pe = pm_storage_adapter.add_policy_class(unique_identifier, policy_machine_uuid, extra_attributes)
-      new_pe
-    end
-
     protected
     def allowed_assignee_classes
       []

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -40,9 +40,7 @@ module PolicyMachineStorageAdapter
       has_many :assignments, foreign_key: :parent_id, dependent: :destroy
       has_many :children, through: :assignments, dependent: :destroy #this doesn't actually destroy the children, just the assignment
 
-      attr_accessor :extra_attributes_hash
-
-      serialize :extra_attributes, JSON
+      store_accessor :extra_attributes
 
       def method_missing(meth, *args, &block)
         store_attributes

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -40,7 +40,9 @@ module PolicyMachineStorageAdapter
       has_many :assignments, foreign_key: :parent_id, dependent: :destroy
       has_many :children, through: :assignments, dependent: :destroy #this doesn't actually destroy the children, just the assignment
 
-      store_accessor :extra_attributes
+      attr_accessor :extra_attributes_hash
+
+      serialize :extra_attributes, JSON
 
       def method_missing(meth, *args, &block)
         store_attributes

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -204,7 +204,7 @@ shared_examples "a policy machine" do
   end
 
   describe 'All methods for policy elements' do
-    (PolicyMachine::POLICY_ELEMENT_TYPES - %w(policy_class)).each do |pe_type|
+    PolicyMachine::POLICY_ELEMENT_TYPES.each do |pe_type|
       it "returns an array of all #{pe_type.to_s.pluralize}" do
         pe = policy_machine.send("create_#{pe_type}", 'some name')
         policy_machine.send(pe_type.to_s.pluralize).should == [pe]
@@ -215,14 +215,6 @@ shared_examples "a policy machine" do
         other_pm = PolicyMachine.new
         pe_in_other_machine = other_pm.send("create_#{pe_type}", 'some name')
         policy_machine.send(pe_type.to_s.pluralize).should == [pe]
-      end
-    end
-
-    (PolicyMachine::POLICY_ELEMENT_TYPES - %w(user user_attribute object object_attribute operation)).each do |pe_type|
-      it "raises when calling #{pe_type.to_s.pluralize}" do
-        pe = policy_machine.send("create_#{pe_type}", 'some name')
-        expect{ policy_machine.send(pe_type.to_s.pluralize) }
-          .to raise_error(NoMethodError)
       end
     end
   end

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -27,8 +27,8 @@ shared_examples "a policy machine" do
 
     it 'raises when uuid is blank' do
       ['', '   '].each do |blank_value|
-        expect{ PolicyMachine.new(:uuid => blank_value) }.
-          to raise_error(ArgumentError, 'uuid cannot be blank')
+        expect{ PolicyMachine.new(:uuid => blank_value) }
+          .to raise_error(ArgumentError, 'uuid cannot be blank')
       end
     end
 
@@ -42,7 +42,6 @@ shared_examples "a policy machine" do
           should be_a(::PolicyMachineStorageAdapter::Neography)
       end
     end
-
   end
 
   describe 'Assignments' do
@@ -80,30 +79,30 @@ shared_examples "a policy machine" do
 
       it 'raises when first argument is not a policy element' do
         pe = policy_machine.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_assignment(1, pe) }.
-          to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
+        expect{ policy_machine.add_assignment(1, pe) }
+          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
       end
 
       it 'raises when first argument is not in policy machine' do
         pm2 = PolicyMachine.new
         pe0 = pm2.create_user_attribute(SecureRandom.uuid)
         pe1 = policy_machine.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_assignment(pe0, pe1) }.
-          to raise_error(ArgumentError, "#{pe0.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
+        expect{ policy_machine.add_assignment(pe0, pe1) }
+          .to raise_error(ArgumentError, "#{pe0.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
 
       it 'raises when second argument is not a policy element' do
         pe = policy_machine.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_assignment(pe, "hello") }.
-          to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got String instead")
+        expect{ policy_machine.add_assignment(pe, "hello") }
+          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got String instead")
       end
 
       it 'raises when second argument is not in policy machine' do
         pm2 = PolicyMachine.new
         pe0 = policy_machine.create_user_attribute(SecureRandom.uuid)
         pe1 = pm2.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_assignment(pe0, pe1) }.
-          to raise_error(ArgumentError, "#{pe1.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
+        expect{ policy_machine.add_assignment(pe0, pe1) }
+          .to raise_error(ArgumentError, "#{pe1.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
     end
 
@@ -123,29 +122,29 @@ shared_examples "a policy machine" do
       end
 
       it 'raises when first argument is not a policy element' do
-        expect{ policy_machine.add_assignment(1, @pe1) }.
-          to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
+        expect{ policy_machine.add_assignment(1, @pe1) }
+          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
       end
 
       it 'raises when first argument is not in policy machine' do
         pm2 = PolicyMachine.new
         pe0 = pm2.create_user_attribute(SecureRandom.uuid)
         pe1 = policy_machine.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.remove_assignment(pe0, pe1) }.
-          to raise_error(ArgumentError, "#{pe0.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
+        expect{ policy_machine.remove_assignment(pe0, pe1) }
+          .to raise_error(ArgumentError, "#{pe0.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
 
       it 'raises when second argument is not a policy element' do
-        expect{ policy_machine.add_assignment(@pe0, "hello") }.
-          to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got String instead")
+        expect{ policy_machine.add_assignment(@pe0, "hello") }
+          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got String instead")
       end
 
       it 'raises when second argument is not in policy machine' do
         pm2 = PolicyMachine.new
         pe0 = policy_machine.create_user_attribute(SecureRandom.uuid)
         pe1 = pm2.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.remove_assignment(pe0, pe1) }.
-          to raise_error(ArgumentError, "#{pe1.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
+        expect{ policy_machine.remove_assignment(pe0, pe1) }
+          .to raise_error(ArgumentError, "#{pe1.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
     end
   end
@@ -168,8 +167,8 @@ shared_examples "a policy machine" do
       it 'raises when first argument is not in policy machine' do
         pm2 = PolicyMachine.new
         ua = pm2.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_association(ua, @operation_set, @object_attribute) }.
-          to raise_error(ArgumentError, "#{ua.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
+        expect{ policy_machine.add_association(ua, @operation_set, @object_attribute) }
+          .to raise_error(ArgumentError, "#{ua.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
 
       it 'raises when third argument is not a PolicyElement' do
@@ -180,8 +179,8 @@ shared_examples "a policy machine" do
       it 'raises when third argument is not in policy machine' do
         pm2 = PolicyMachine.new
         oa = pm2.create_object_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_association(@user_attribute, @operation_set, oa) }.
-          to raise_error(ArgumentError, "#{oa.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
+        expect{ policy_machine.add_association(@user_attribute, @operation_set, oa) }
+          .to raise_error(ArgumentError, "#{oa.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
 
       it 'allows an association to be made between an existing user_attribute, operation set and object attribute (returns true)' do
@@ -200,9 +199,7 @@ shared_examples "a policy machine" do
           .to change{ policy_machine.scoped_privileges(@user_attribute, @object_attribute) }
           .from( [[@user_attribute, @operation1, @object_attribute]] )
           .to(   [[@user_attribute, @operation2, @object_attribute]] )
-
       end
-
     end
   end
 
@@ -224,14 +221,13 @@ shared_examples "a policy machine" do
     (PolicyMachine::POLICY_ELEMENT_TYPES - %w(user user_attribute object object_attribute operation)).each do |pe_type|
       it "raises when calling #{pe_type.to_s.pluralize}" do
         pe = policy_machine.send("create_#{pe_type}", 'some name')
-        expect{ policy_machine.send(pe_type.to_s.pluralize) }.
-          to raise_error(NoMethodError)
+        expect{ policy_machine.send(pe_type.to_s.pluralize) }
+          .to raise_error(NoMethodError)
       end
     end
   end
 
   describe 'Operations' do
-
     it 'does not allow an operation to start with a ~' do
       expect{policy_machine.create_operation('~apple')}.to raise_error(ArgumentError)
       expect{policy_machine.create_operation('apple~')}.not_to raise_error
@@ -258,37 +254,28 @@ shared_examples "a policy machine" do
     it 'can negate operations expressed as PM::Operations' do
       expect(PM::Prohibition.on(policy_machine.create_operation('fly'))).to be_a PM::Operation
     end
-
   end
 
   describe 'User Attributes' do
-
     describe '#extra_attributes' do
-
       it 'accepts and persists arbitrary extra attributes' do
         @ua = policy_machine.create_user_attribute('ua1', foo: 'bar')
         @ua.foo.should == 'bar'
         policy_machine.user_attributes.last.foo.should == 'bar'
       end
-
     end
 
     describe '#delete' do
-
       it 'successfully deletes itself' do
         @ua = policy_machine.create_user_attribute('ua1')
         @ua.delete
         policy_machine.user_attributes.should_not include(@ua)
       end
-
     end
-
   end
 
   describe 'Users' do
-
     describe '#extra_attributes' do
-
       it 'accepts and persists arbitrary extra attributes' do
         @u = policy_machine.create_user('u1', foo: 'bar')
         @u.foo.should == 'bar'
@@ -326,9 +313,7 @@ shared_examples "a policy machine" do
           policy_machine.users(foo: 'bar', attitude: 'sassy').should be_none
         end
       end
-
     end
-
   end
 
   describe '#is_privilege?' do
@@ -488,9 +473,7 @@ shared_examples "a policy machine" do
           policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => @group1, 'in_object_attribute' => project2).
             should be_false
         end
-
       end
-
     end
   end
 
@@ -520,7 +503,6 @@ shared_examples "a policy machine" do
     it 'raises an argument error when passed anything other than a user' do
       expect {policy_machine.list_user_attributes(@group1)}.to raise_error ArgumentError, /Expected a PM::User/
     end
-
   end
 
   describe '#transaction' do
@@ -671,7 +653,6 @@ shared_examples "a policy machine" do
       with_prohibitions = policy_machine.scoped_privileges(@u2, @in_u2).map{ |_,op,_| op.unique_identifier }
       expect(ignoring_prohibitions - with_prohibitions).to eq([@w.unique_identifier])
     end
-
   end
 
   describe 'The DAC Operating System:  Figure 11. (pg. 47)' do


### PR DESCRIPTION
This PR moves some duplicated logic into the Policy Element base class.

[This spec](https://github.com/mdsol/the_policy_machine/blob/develop/spec/support/shared_examples_policy_machine.rb#L224) is failing. @HonoreDB how much do you like that spec?

rspec
```
Failures:

  1) PolicyMachine behaves like a policy machine All methods for policy elements raises when calling policy_classes
     Failure/Error: expect{ policy_machine.send(pe_type.to_s.pluralize) }.
       expected NoMethodError but nothing was raised
     Shared Example Group: "a policy machine" called from ./spec/policy_machine_spec.rb:4
     # ./spec/support/shared_examples_policy_machine.rb:227:in `block (4 levels) in <top (required)>'

  2) ActiveRecord PolicyMachine integration with PolicyMachineStorageAdapter::ActiveRecord behaves like a policy machine All methods for policy elements raises when calling policy_classes
     Failure/Error: expect{ policy_machine.send(pe_type.to_s.pluralize) }.
       expected NoMethodError but nothing was raised
     Shared Example Group: "a policy machine" called from ./spec/policy_machine_storage_adapters/active_record_spec.rb:118
     # ./spec/support/shared_examples_policy_machine.rb:227:in `block (4 levels) in <top (required)>'

  3) PolicyMachine integration with PolicyMachineStorageAdapter::InMemory behaves like a policy machine All methods for policy elements raises when calling policy_classes
     Failure/Error: expect{ policy_machine.send(pe_type.to_s.pluralize) }.
       expected NoMethodError but nothing was raised
     Shared Example Group: "a policy machine" called from ./spec/policy_machine_storage_adapters/in_memory_spec.rb:39
     # ./spec/support/shared_examples_policy_machine.rb:227:in `block (4 levels) in <top (required)>'

Finished in 30.14 seconds
677 examples, 3 failures, 12 pending

Failed examples:

rspec ./spec/support/shared_examples_policy_machine.rb:225 # PolicyMachine behaves like a policy machine All methods for policy elements raises when calling policy_classes
rspec ./spec/support/shared_examples_policy_machine.rb:225 # ActiveRecord PolicyMachine integration with PolicyMachineStorageAdapter::ActiveRecord behaves like a policy machine All methods for policy elements raises when calling policy_classes
rspec ./spec/support/shared_examples_policy_machine.rb:225 # PolicyMachine integration with PolicyMachineStorageAdapter::InMemory behaves like a policy machine All methods for policy elements raises when calling policy_classes
```