### PR TITLE
Feature/generic batch writes

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -272,8 +272,9 @@ class PolicyMachine
     if policy_machine_storage_adapter.respond_to?(:bulk_create!)
       begin
         self.bulk_creating = true
-        yield
+        result = yield
         policy_machine_storage_adapter.bulk_create!
+        result
       ensure
         self.bulk_creating = false
         policy_machine_storage_adapter.clear_buffer!

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -272,7 +272,7 @@ class PolicyMachine
     if policy_machine_storage_adapter.respond_to?(:bulk_create!)
       bulk_creator = clone
       bulk_creator.bulk_creating = true
-      bulk_creator.instance_exec(block)
+      bulk_creator.instance_exec(&block)
       bulk_creator.bulk_create!
     else
       yield

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -268,12 +268,15 @@ class PolicyMachine
     policy_machine_storage_adapter.transaction(&block)
   end
 
-  def bulk_create(&block)
+  def bulk_create
     if policy_machine_storage_adapter.respond_to?(:bulk_create!)
-      bulk_creator = clone
-      bulk_creator.bulk_creating = true
-      bulk_creator.instance_exec(&block)
-      bulk_creator.bulk_create!
+      begin
+        self.bulk_creating = true
+        yield
+        policy_machine_storage_adapter.bulk_create!
+      ensure
+        self.bulk_creating = false
+      end
     else
       yield
     end

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -34,7 +34,7 @@ class PolicyMachine
     assert_policy_element_in_machine(src_policy_element)
     assert_policy_element_in_machine(dst_policy_element)
 
-    src_policy_element.assign_to(dst_policy_element)
+    src_policy_element.assign_to(dst_policy_element, self.bulk_creating)
   end
 
   ##
@@ -56,7 +56,7 @@ class PolicyMachine
     operation_set.each{ |op| assert_policy_element_in_machine(op) }
     assert_policy_element_in_machine(object_attribute_pe)
 
-    PM::Association.create(user_attribute_pe, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter)
+    PM::Association.create(user_attribute_pe, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter, self.bulk_creating)
   end
 
   ##
@@ -276,6 +276,7 @@ class PolicyMachine
         policy_machine_storage_adapter.bulk_create!
       ensure
         self.bulk_creating = false
+        policy_machine_storage_adapter.clear_buffer!
       end
     else
       yield

--- a/lib/policy_machine/association.rb
+++ b/lib/policy_machine/association.rb
@@ -37,7 +37,7 @@ module PM
 
     # Create an association given persisted policy elements
     #
-    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter)
+    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter, bulk_creating = false)
       # argument errors for user_attribute_pe
       raise(ArgumentError, "user_attribute_pe must be a UserAttribute.") unless user_attribute_pe.is_a?(PM::UserAttribute)
       unless user_attribute_pe.policy_machine_uuid == policy_machine_uuid
@@ -62,7 +62,9 @@ module PM
         raise(ArgumentError, "object_attribute_pe must be in policy machine with uuid #{policy_machine_uuid}")
       end
 
-      new_assoc = pm_storage_adapter.add_association(
+      meth = bulk_creating ? :add_association_later : :add_association
+
+      new_assoc = pm_storage_adapter.public_send(meth,
         user_attribute_pe.stored_pe,
         Set.new(operation_set.map(&:stored_pe)),
         object_attribute_pe.stored_pe,

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -27,11 +27,15 @@ module PM
 
     # Assigns self to destination policy element
     # This method is sensitive to the type of self and dst_policy_element
-    def assign_to(dst_policy_element)
+    def assign_to(dst_policy_element, bulk_creating = false)
       unless allowed_assignee_classes.any?{|aac| dst_policy_element.is_a?(aac)}
         raise(ArgumentError, "expected dst_policy_element to be one of #{allowed_assignee_classes.to_s}; got #{dst_policy_element.class} instead.")
       end
-      @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)
+      if bulk_creating
+        @pm_storage_adapter.assign_later(parent: self.stored_pe, child: dst_policy_element.stored_pe)
+      else
+        @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)
+      end
     end
 
     # Removes assignment from self to destination policy element

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -107,6 +107,13 @@ module PM
       new_pe
     end
 
+    def self.create_later(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
+      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
+      method_name = "bulk_add_#{self.name.split('::').last}".underscore.to_sym
+      new_pe.stored_pe = pm_storage_adapter.send(method_name, unique_identifier, policy_machine_uuid, extra_attributes)
+      new_pe
+    end
+
     # Returns all policy elements of a particular type (e.g. all users)
     # TODO: Move all overrides of self.all to the base class
     def self.all(pm_storage_adapter, options = {})

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -83,7 +83,7 @@ module PolicyMachineStorageAdapter
       end
 
       def self.create_later(*args)
-        elements_to_create << new(args)
+        elements_to_create << new(*args)
       end
 
       def self.elements_to_create

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -406,6 +406,10 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    def bulk_create!
+      PolicyElement.bulk_create!
+    end
+
     private
 
     def relevant_associations(user_or_attribute, operation, object_or_attribute)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -133,7 +133,7 @@ module PolicyMachineStorageAdapter
       def self.bulk_create_assignments
         assignments_to_create.map! do |attrs|
           [attrs[:parent].id, attrs[:child].id]
-        end
+        end.uniq!
         Assignment.import([:parent_id, :child_id], assignments_to_create, on_duplicate_key_ignore: true)
       end
 

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('will_paginate')
 
   # Only required in ActiveRecord mode
-  s.add_dependency('activerecord-import', '~> 0.0')
+  s.add_dependency('activerecord-import', '~> 0.12')
     # Only required for mysql
     s.add_dependency('mysql2')
     # Only required for postgres

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -595,7 +595,6 @@ shared_examples "a policy machine" do
 
   describe 'The Mail System:  Figure 8. (pg. 43)' do
     before do
-      policy_machine.bulk_create do
       # Users
       @u2 = policy_machine.create_user('u2')
 
@@ -639,7 +638,6 @@ shared_examples "a policy machine" do
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @out_u2)
       policy_machine.add_association(@id_u2, Set.new([@w]), @inboxes)
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @other_u2)
-      end
     end
 
     it 'returns all and only these privileges encoded by the policy machine' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -521,70 +521,81 @@ shared_examples "a policy machine" do
 
   describe '#privileges' do
 
-    # This PM is taken from the policy machine spec, Figure 4. (pg. 19)
-    describe 'Simple Example:  Figure 4. (pg. 19)' do
-      before do
-        # Users
-        @u1 = policy_machine.create_user('u1')
-        @u2 = policy_machine.create_user('u2')
-        @u3 = policy_machine.create_user('u3')
+    [nil, ' in bulk create mode'].each do |bulk_create_mode|
 
-        # Objects
-        @o1 = policy_machine.create_object('o1')
-        @o2 = policy_machine.create_object('o2')
-        @o3 = policy_machine.create_object('o3')
+      # This PM is taken from the policy machine spec, Figure 4. (pg. 19)
+      describe "Simple Example:  Figure 4. (pg. 19)#{bulk_create_mode}" do
+        before do
+            inserts = lambda do
+            # Users
+            @u1 = policy_machine.create_user('u1')
+            @u2 = policy_machine.create_user('u2')
+            @u3 = policy_machine.create_user('u3')
 
-        # User Attributes
-        @group1 = policy_machine.create_user_attribute('Group1')
-        @group2 = policy_machine.create_user_attribute('Group2')
-        @division = policy_machine.create_user_attribute('Division')
+            # Objects
+            @o1 = policy_machine.create_object('o1')
+            @o2 = policy_machine.create_object('o2')
+            @o3 = policy_machine.create_object('o3')
 
-        # Object Attributes
-        @project1 = policy_machine.create_object_attribute('Project1')
-        @project2 = policy_machine.create_object_attribute('Project2')
-        @projects = policy_machine.create_object_attribute('Projects')
+            # User Attributes
+            @group1 = policy_machine.create_user_attribute('Group1')
+            @group2 = policy_machine.create_user_attribute('Group2')
+            @division = policy_machine.create_user_attribute('Division')
 
-        # Operations
-        @r = policy_machine.create_operation('read')
-        @w = policy_machine.create_operation('write')
+            # Object Attributes
+            @project1 = policy_machine.create_object_attribute('Project1')
+            @project2 = policy_machine.create_object_attribute('Project2')
+            @projects = policy_machine.create_object_attribute('Projects')
 
-        # Policy Classes
-        @ou = policy_machine.create_policy_class("OU")
+            # Operations
+            @r = policy_machine.create_operation('read')
+            @w = policy_machine.create_operation('write')
 
-        # Assignments
-        policy_machine.add_assignment(@u1, @group1)
-        policy_machine.add_assignment(@u2, @group2)
-        policy_machine.add_assignment(@u3, @division)
-        policy_machine.add_assignment(@group1, @division)
-        policy_machine.add_assignment(@group2, @division)
-        policy_machine.add_assignment(@o1, @project1)
-        policy_machine.add_assignment(@o2, @project1)
-        policy_machine.add_assignment(@o3, @project2)
-        policy_machine.add_assignment(@project1, @projects)
-        policy_machine.add_assignment(@project2, @projects)
-        policy_machine.add_assignment(@division, @ou)
-        policy_machine.add_assignment(@projects, @ou)
+            # Policy Classes
+            @ou = policy_machine.create_policy_class("OU")
 
-        # Associations
-        policy_machine.add_association(@group1, Set.new([@w]), @project1)
-        policy_machine.add_association(@group2, Set.new([@w]), @project2)
-        policy_machine.add_association(@division, Set.new([@r]), @projects)
-      end
+            # Assignments
+            policy_machine.add_assignment(@u1, @group1)
+            policy_machine.add_assignment(@u2, @group2)
+            policy_machine.add_assignment(@u3, @division)
+            policy_machine.add_assignment(@group1, @division)
+            policy_machine.add_assignment(@group2, @division)
+            policy_machine.add_assignment(@o1, @project1)
+            policy_machine.add_assignment(@o2, @project1)
+            policy_machine.add_assignment(@o3, @project2)
+            policy_machine.add_assignment(@project1, @projects)
+            policy_machine.add_assignment(@project2, @projects)
+            policy_machine.add_assignment(@division, @ou)
+            policy_machine.add_assignment(@projects, @ou)
 
-      it 'returns all and only these privileges encoded by the policy machine' do
-        expected_privileges = [
-          [@u1, @w, @o1], [@u1, @w, @o2], [@u1, @r, @o1], [@u1, @r, @o2], [@u1, @r, @o3],
-          [@u2, @w, @o3], [@u2, @r, @o1], [@u2, @r, @o2], [@u2, @r, @o3],
-          [@u3, @r, @o1], [@u3, @r, @o2], [@u3, @r, @o3]
-        ]
+            # Associations
+            policy_machine.add_association(@group1, Set.new([@w]), @project1)
+            policy_machine.add_association(@group2, Set.new([@w]), @project2)
+            policy_machine.add_association(@division, Set.new([@r]), @projects)
+          end
+          if bulk_create_mode
+            policy_machine.bulk_create(&inserts)
+          else
+            inserts.call
+          end
+        end
 
-        assert_pm_privilege_expectations(policy_machine.privileges, expected_privileges)
+        it 'returns all and only these privileges encoded by the policy machine' do
+          expected_privileges = [
+            [@u1, @w, @o1], [@u1, @w, @o2], [@u1, @r, @o1], [@u1, @r, @o2], [@u1, @r, @o3],
+            [@u2, @w, @o3], [@u2, @r, @o1], [@u2, @r, @o2], [@u2, @r, @o3],
+            [@u3, @r, @o1], [@u3, @r, @o2], [@u3, @r, @o3]
+          ]
+
+          assert_pm_privilege_expectations(policy_machine.privileges, expected_privileges)
+        end
       end
     end
   end
 
   describe 'The Mail System:  Figure 8. (pg. 43)' do
     before do
+      policy_machine.bulk_create do
       # Users
       @u2 = policy_machine.create_user('u2')
 
@@ -628,6 +639,7 @@ shared_examples "a policy machine" do
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @out_u2)
       policy_machine.add_association(@id_u2, Set.new([@w]), @inboxes)
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @other_u2)
+      end
     end
 
     it 'returns all and only these privileges encoded by the policy machine' do


### PR DESCRIPTION
Adds the ability to write to an in-memory buffer, then insert it all at once into the persistent store. Implements it only in active_record, since it's meaningless in-memory and we don't have an optimized neo4j adapter yet.

Just for review right now, @CGDS wants to add bulk delete and bulk update capabilities so we'll work on that tomorrow. Also I haven't actually tested this against Postgres 9.5 yet, which is necessary to turn on some of the optimizations.