### PR TITLE
Feature/batch spike

### DIFF
--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'policy_machine/policy_element'
 require 'policy_machine/association'
 require 'securerandom'
@@ -267,6 +268,10 @@ class PolicyMachine
     policy_machine_storage_adapter.transaction(&block)
   end
 
+  # TODO: For now, the adapter class itself mitigates buffering, so multiple instances of the
+  # adapter may share the same buffer.  In the future, we will move this to be adapter
+  # instance specific, so multiple policy machines sharing the same adapter may also
+  # share the same buffer without leaking global state.
   def bulk_persist
     adapter_class = policy_machine_storage_adapter.class
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -269,15 +269,17 @@ class PolicyMachine
   end
 
   def bulk_persist
-    if policy_machine_storage_adapter.can_buffer?
+    adapter_class = policy_machine_storage_adapter.class
+
+    if adapter_class.can_buffer?
       begin
-        self.start_buffering!
+        adapter_class.start_buffering!
         result = yield
-        policy_machine_storage_adapter.bulk_persist!
+        adapter_class.persist_buffers!
         result
       ensure
-        self.stop_buffering!
-        policy_machine_storage_adapter.clear_buffers!
+        adapter_class.stop_buffering!
+        adapter_class.clear_buffers!
       end
     else
       yield

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -242,8 +242,7 @@ class PolicyMachine
     define_method("create_#{pe_type}") do |unique_identifier, extra_attributes = {}|
       # when creating a policy element, we provide a unique_identifier, the uuid of this policy machine
       # and a policy machine storage adapter to allow us to persist the policy element.
-      meth = self.bulk_persisting ? :create_later : :create
-      pm_class.send(meth, unique_identifier, @uuid, @policy_machine_storage_adapter, extra_attributes)
+      pm_class.send(:create, unique_identifier, @uuid, @policy_machine_storage_adapter, extra_attributes)
     end
 
     ##

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -272,8 +272,9 @@ class PolicyMachine
     if policy_machine_storage_adapter.respond_to?(:bulk_create!)
       begin
         self.bulk_creating = true
-        yield
+        result = yield
         policy_machine_storage_adapter.bulk_create!
+        result
       ensure
         self.bulk_creating = false
         policy_machine_storage_adapter.clear_buffer!

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -272,7 +272,7 @@ class PolicyMachine
     if policy_machine_storage_adapter.respond_to?(:bulk_create!)
       bulk_creator = clone
       bulk_creator.bulk_creating = true
-      bulk_creator.instance_exec(block)
+      bulk_creator.instance_exec(&block)
       bulk_creator.bulk_create!
     else
       yield

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -271,7 +271,7 @@ class PolicyMachine
   def bulk_persist
     adapter_class = policy_machine_storage_adapter.class
 
-    if adapter_class.can_buffer?
+    if adapter_class.respond_to?(:buffering?)
       begin
         adapter_class.start_buffering!
         result = yield

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -273,6 +273,7 @@ class PolicyMachine
 
     if adapter_class.respond_to?(:buffering?)
       begin
+        adapter_class.clear_buffers!
         adapter_class.start_buffering!
         result = yield
         adapter_class.persist_buffers!

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -274,11 +274,11 @@ class PolicyMachine
       begin
         self.bulk_persisting = true
         result = yield
-        policy_machine_storage_adapter.bulk_create!
+        policy_machine_storage_adapter.bulk_persist!
         result
       ensure
         self.bulk_persisting = false
-        policy_machine_storage_adapter.clear_buffer!
+        policy_machine_storage_adapter.clear_buffers!
       end
     else
       yield
@@ -289,8 +289,8 @@ class PolicyMachine
 
   attr_accessor :bulk_persisting
 
-  def bulk_create!
-    policy_machine_storage_adapter.bulk_create!
+  def bulk_persist!
+    policy_machine_storage_adapter.bulk_persist!
   end
 
   private

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -268,12 +268,15 @@ class PolicyMachine
     policy_machine_storage_adapter.transaction(&block)
   end
 
-  def bulk_create(&block)
+  def bulk_create
     if policy_machine_storage_adapter.respond_to?(:bulk_create!)
-      bulk_creator = clone
-      bulk_creator.bulk_creating = true
-      bulk_creator.instance_exec(&block)
-      bulk_creator.bulk_create!
+      begin
+        self.bulk_creating = true
+        yield
+        policy_machine_storage_adapter.bulk_create!
+      ensure
+        self.bulk_creating = false
+      end
     else
       yield
     end

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'policy_machine/policy_element'
 require 'policy_machine/association'
 require 'securerandom'

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -34,7 +34,7 @@ class PolicyMachine
     assert_policy_element_in_machine(src_policy_element)
     assert_policy_element_in_machine(dst_policy_element)
 
-    src_policy_element.assign_to(dst_policy_element)
+    src_policy_element.assign_to(dst_policy_element, self.bulk_creating)
   end
 
   ##
@@ -56,7 +56,7 @@ class PolicyMachine
     operation_set.each{ |op| assert_policy_element_in_machine(op) }
     assert_policy_element_in_machine(object_attribute_pe)
 
-    PM::Association.create(user_attribute_pe, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter)
+    PM::Association.create(user_attribute_pe, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter, self.bulk_creating)
   end
 
   ##
@@ -276,6 +276,7 @@ class PolicyMachine
         policy_machine_storage_adapter.bulk_create!
       ensure
         self.bulk_creating = false
+        policy_machine_storage_adapter.clear_buffer!
       end
     else
       yield

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -270,7 +270,7 @@ class PolicyMachine
   end
 
   def bulk_persist
-    if policy_machine_storage_adapter.respond_to?(:bulk_create!)
+    if policy_machine_storage_adapter.respond_to?(:bulk_persist!)
       begin
         self.bulk_persisting = true
         result = yield

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -35,7 +35,7 @@ class PolicyMachine
     assert_policy_element_in_machine(src_policy_element)
     assert_policy_element_in_machine(dst_policy_element)
 
-    src_policy_element.assign_to(dst_policy_element, self.bulk_persisting)
+    src_policy_element.assign_to(dst_policy_element)
   end
 
   ##
@@ -57,7 +57,7 @@ class PolicyMachine
     operation_set.each{ |op| assert_policy_element_in_machine(op) }
     assert_policy_element_in_machine(object_attribute_pe)
 
-    PM::Association.create(user_attribute_pe, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter, self.bulk_persisting)
+    PM::Association.create(user_attribute_pe, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter)
   end
 
   ##
@@ -270,14 +270,14 @@ class PolicyMachine
   end
 
   def bulk_persist
-    if policy_machine_storage_adapter.respond_to?(:bulk_persist!)
+    if policy_machine_storage_adapter.can_buffer?
       begin
-        self.bulk_persisting = true
+        self.start_buffering!
         result = yield
         policy_machine_storage_adapter.bulk_persist!
         result
       ensure
-        self.bulk_persisting = false
+        self.stop_buffering!
         policy_machine_storage_adapter.clear_buffers!
       end
     else

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -284,14 +284,6 @@ class PolicyMachine
     end
   end
 
-  protected
-
-  attr_accessor :bulk_persisting
-
-  def bulk_persist!
-    policy_machine_storage_adapter.bulk_persist!
-  end
-
   private
 
     # Raise unless the argument is a policy element.

--- a/lib/policy_machine/association.rb
+++ b/lib/policy_machine/association.rb
@@ -37,7 +37,7 @@ module PM
 
     # Create an association given persisted policy elements
     #
-    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter)
+    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter, bulk_creating = false)
       # argument errors for user_attribute_pe
       raise(ArgumentError, "user_attribute_pe must be a UserAttribute.") unless user_attribute_pe.is_a?(PM::UserAttribute)
       unless user_attribute_pe.policy_machine_uuid == policy_machine_uuid
@@ -62,7 +62,9 @@ module PM
         raise(ArgumentError, "object_attribute_pe must be in policy machine with uuid #{policy_machine_uuid}")
       end
 
-      new_assoc = pm_storage_adapter.add_association(
+      meth = bulk_creating ? :add_association_later : :add_association
+
+      new_assoc = pm_storage_adapter.public_send(meth,
         user_attribute_pe.stored_pe,
         Set.new(operation_set.map(&:stored_pe)),
         object_attribute_pe.stored_pe,

--- a/lib/policy_machine/association.rb
+++ b/lib/policy_machine/association.rb
@@ -37,7 +37,7 @@ module PM
 
     # Create an association given persisted policy elements
     #
-    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter, bulk_persisting = false)
+    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter)
       # argument errors for user_attribute_pe
       raise(ArgumentError, "user_attribute_pe must be a UserAttribute.") unless user_attribute_pe.is_a?(PM::UserAttribute)
       unless user_attribute_pe.policy_machine_uuid == policy_machine_uuid
@@ -62,9 +62,7 @@ module PM
         raise(ArgumentError, "object_attribute_pe must be in policy machine with uuid #{policy_machine_uuid}")
       end
 
-      meth = bulk_persisting ? :add_association_later : :add_association
-
-      new_assoc = pm_storage_adapter.public_send(meth,
+      pm_storage_adapter.add_association(
         user_attribute_pe.stored_pe,
         Set.new(operation_set.map(&:stored_pe)),
         object_attribute_pe.stored_pe,

--- a/lib/policy_machine/association.rb
+++ b/lib/policy_machine/association.rb
@@ -37,7 +37,7 @@ module PM
 
     # Create an association given persisted policy elements
     #
-    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter, bulk_creating = false)
+    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter, bulk_persisting = false)
       # argument errors for user_attribute_pe
       raise(ArgumentError, "user_attribute_pe must be a UserAttribute.") unless user_attribute_pe.is_a?(PM::UserAttribute)
       unless user_attribute_pe.policy_machine_uuid == policy_machine_uuid
@@ -62,7 +62,7 @@ module PM
         raise(ArgumentError, "object_attribute_pe must be in policy machine with uuid #{policy_machine_uuid}")
       end
 
-      meth = bulk_creating ? :add_association_later : :add_association
+      meth = bulk_persisting ? :add_association_later : :add_association
 
       new_assoc = pm_storage_adapter.public_send(meth,
         user_attribute_pe.stored_pe,

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -105,13 +105,10 @@ module PM
     end
 
     def self.create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
+      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
       method_name = "add_#{self.name.split('::').last}".underscore.to_sym
-      base_create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes, method_name)
-    end
-
-    def self.create_later(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
-      method_name = "bulk_add_#{self.name.split('::').last}".underscore.to_sym
-      base_create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes, method_name)
+      new_pe.stored_pe = pm_storage_adapter.send(method_name, unique_identifier, policy_machine_uuid, extra_attributes)
+      new_pe
     end
 
     # Returns all policy elements of a particular type (e.g. all users)
@@ -124,14 +121,6 @@ module PM
       end
       all_result.define_singleton_method(:total_entries) { result.total_entries }
       all_result
-    end
-
-    private
-
-    def self.base_create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes, method_name)
-      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
-      new_pe.stored_pe = pm_storage_adapter.send(method_name, unique_identifier, policy_machine_uuid, extra_attributes)
-      new_pe
     end
 
   end

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -27,11 +27,15 @@ module PM
 
     # Assigns self to destination policy element
     # This method is sensitive to the type of self and dst_policy_element
-    def assign_to(dst_policy_element)
+    def assign_to(dst_policy_element, bulk_creating = false)
       unless allowed_assignee_classes.any?{|aac| dst_policy_element.is_a?(aac)}
         raise(ArgumentError, "expected dst_policy_element to be one of #{allowed_assignee_classes.to_s}; got #{dst_policy_element.class} instead.")
       end
-      @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)
+      if bulk_creating
+        @pm_storage_adapter.assign_later(parent: self.stored_pe, child: dst_policy_element.stored_pe)
+      else
+        @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)
+      end
     end
 
     # Removes assignment from self to destination policy element

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -107,6 +107,13 @@ module PM
       new_pe
     end
 
+    def self.create_later(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
+      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
+      method_name = "bulk_add_#{self.name.split('::').last}".underscore.to_sym
+      new_pe.stored_pe = pm_storage_adapter.send(method_name, unique_identifier, policy_machine_uuid, extra_attributes)
+      new_pe
+    end
+
     # Returns all policy elements of a particular type (e.g. all users)
     # TODO: Move all overrides of self.all to the base class
     def self.all(pm_storage_adapter, options = {})

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -57,18 +57,11 @@ module PM
     # Updates extra attributes with the passed-in values. Will not remove other
     # attributes not in the hash. Returns true if no errors occurred.
     def update(attr_hash)
-      self.pm_storage_adapter.buffering? ? update_later(attr_hash) : update_now(attr_hash)
-    end
-
-    def update_now(attr_hash)
       @extra_attributes.merge!(attr_hash)
       if self.stored_pe && self.stored_pe.persisted
         @pm_storage_adapter.update(self.stored_pe, attr_hash)
         true
       end
-    end
-
-    def update_later(attr_hash)
     end
 
     # Converts a stored_pe to an instantiated pe

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -58,6 +58,7 @@ module PM
     # attributes not in the hash. Returns true if no errors occurred.
     def update(attr_hash)
       @extra_attributes.merge!(attr_hash)
+      #TODO: consider removing the persisted check to allow for buffered writes
       if self.stored_pe && self.stored_pe.persisted
         @pm_storage_adapter.update(self.stored_pe, attr_hash)
         true

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -104,12 +104,6 @@ module PM
       raise "Must override this method in a subclass"
     end
 
-    private def self.base_create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes, method_name)
-      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
-      new_pe.stored_pe = pm_storage_adapter.send(method_name, unique_identifier, policy_machine_uuid, extra_attributes)
-      new_pe
-    end
-
     def self.create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {})
       method_name = "add_#{self.name.split('::').last}".underscore.to_sym
       base_create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes, method_name)
@@ -131,6 +125,15 @@ module PM
       all_result.define_singleton_method(:total_entries) { result.total_entries }
       all_result
     end
+
+    private
+
+    def self.base_create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes, method_name)
+      new_pe = new(unique_identifier, policy_machine_uuid, pm_storage_adapter, nil, extra_attributes)
+      new_pe.stored_pe = pm_storage_adapter.send(method_name, unique_identifier, policy_machine_uuid, extra_attributes)
+      new_pe
+    end
+
   end
 
   # A user in a policy machine.

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -31,7 +31,7 @@ module PM
       unless allowed_assignee_classes.any?{|aac| dst_policy_element.is_a?(aac)}
         raise(ArgumentError, "expected dst_policy_element to be one of #{allowed_assignee_classes.to_s}; got #{dst_policy_element.class} instead.")
       end
-      if bulk_creating
+      if bulk_persisting
         @pm_storage_adapter.assign_later(parent: self.stored_pe, child: dst_policy_element.stored_pe)
       else
         @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -31,11 +31,8 @@ module PM
       unless allowed_assignee_classes.any?{|aac| dst_policy_element.is_a?(aac)}
         raise(ArgumentError, "expected dst_policy_element to be one of #{allowed_assignee_classes.to_s}; got #{dst_policy_element.class} instead.")
       end
-      if self.pm_storage_adapter.buffering?
-        @pm_storage_adapter.assign_later(parent: self.stored_pe, child: dst_policy_element.stored_pe)
-      else
-        @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)
-      end
+
+      @pm_storage_adapter.assign(self.stored_pe, dst_policy_element.stored_pe)
     end
 
     # Removes assignment from self to destination policy element

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -333,7 +333,7 @@ module PolicyMachineStorageAdapter
       end
     end
 
-    def self.assign_later(parent:, child:)
+    def assign_later(parent:, child:)
       buffers[:assignments] << [parent, child]
       :buffered
     end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -83,7 +83,7 @@ module PolicyMachineStorageAdapter
       end
 
       def self.create_later(*args)
-        elements_to_create << new(args)
+        elements_to_create << new(*args)
       end
 
       def self.elements_to_create

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -129,7 +129,6 @@ module PolicyMachineStorageAdapter
       def self.create_later(attrs, storage_adapter)
         element = new(attrs)
         storage_adapter.buffers[:upsert][element.unique_identifier] = element
-        element
       end
 
       # NB: delete_all in AR bypasses relation logic, which shouldn't matter here.

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -67,10 +67,8 @@ module PolicyMachineStorageAdapter
       self.class.buffers
     end
 
+    # NB https://github.com/zdennis/activerecord-import/wiki/On-Duplicate-Key-Update
     def self.persist_buffers!
-      # TODO: if postgres needs all conflict targets specified, do we need this to be injectable?
-      # Also, we must move this into the pg adapter, since mysql behaves differently
-      # https://github.com/zdennis/activerecord-import/wiki/On-Duplicate-Key-Update
       column_keys = PolicyElement.column_names.map(&:to_sym)
       PolicyElement.import(buffers[:upsert].values, on_duplicate_key_update: column_keys - [:id])
       PolicyElement.bulk_destroy(buffers[:delete])

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -129,6 +129,7 @@ module PolicyMachineStorageAdapter
       def self.create_later(attrs, storage_adapter)
         element = new(attrs)
         storage_adapter.buffers[:upsert][element.unique_identifier] = element
+        element
       end
 
       # NB: delete_all in AR bypasses relation logic, which shouldn't matter here.

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -406,6 +406,10 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    def bulk_create!
+      PolicyElement.bulk_create!
+    end
+
     private
 
     def relevant_associations(user_or_attribute, operation, object_or_attribute)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -136,11 +136,6 @@ module PolicyMachineStorageAdapter
         :buffered
       end
 
-      #TODO PM uuid potentially useful for future optimization, currently unused
-      def self.associate_later(user_attribute, operation_set, object_attribute, policy_machine_uuid, buffer)
-        buffer << [user_attribute, operation_set, object_attribute, policy_machine_uuid]
-      end
-
       # NB: delete_all in AR bypasses relation logic, which shouldn't matter here.
       def self.bulk_destroy(buffer)
         id_groups = buffer.reduce(Hash.new { |h,k| h[k] = [] }) do |memo,(_,el)|
@@ -414,10 +409,15 @@ module PolicyMachineStorageAdapter
     def add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
       if self.buffering?
         #TODO: move to right class
-        PolicyElement.associate_later(user_attribute, operation_set, object_attribute, policy_machine_uuid, buffers[:associations])
+        associate_later(user_attribute, operation_set, object_attribute, policy_machine_uuid)
       else
         PolicyElementAssociation.add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
       end
+    end
+
+    #TODO PM uuid potentially useful for future optimization, currently unused
+    def associate_later(user_attribute, operation_set, object_attribute, policy_machine_uuid)
+      buffers[:associations] << [user_attribute, operation_set, object_attribute, policy_machine_uuid]
     end
 
     ##

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -55,8 +55,7 @@ module PolicyMachineStorageAdapter
     end
 
     def self.buffers
-      #The associations thing being different is annoying. Causality sucks.
-      @buffers ||= {upsert: {}, delete:{}, assignments: {}, associations: [] }
+      @buffers ||= {upsert: {}, delete:{}, assignments: [], associations: [] }
     end
 
     def self.clear_buffers!
@@ -137,7 +136,7 @@ module PolicyMachineStorageAdapter
       end
 
       def self.assign_later(parent:, child:, buffer:)
-        buffer.merge!(parent => child)
+        buffer << [parent, child]
         :buffered
       end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -506,10 +506,6 @@ module PolicyMachineStorageAdapter
       end
     end
 
-    def add_association_later(user_attribute, operation_set, object_attribute, policy_machine_uuid)
-      PolicyElement.associate_later(user_attribute, operation_set, object_attribute, policy_machine_uuid, buffers[:associations])
-    end
-
     private
 
     def relevant_associations(user_or_attribute, operation, object_or_attribute)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -130,23 +130,10 @@ module PolicyMachineStorageAdapter
         pm_storage_adapter.buffers
       end
 
+      # TODO: support databases that dont support upserts(pg 9.4, etc)
       def self.create_later(attrs, storage_adapter)
         element = new(attrs)
         storage_adapter.buffers[:upsert][element.unique_identifier] = element
-
-        # TODO: Why did we have to do this again? Don't get it
-        # keys_to_ignore = %i[unique_identifier created_at updated_at] #FIXME
-        # already_pending = persistence_elements[:to_upsert].find do |elt|
-        #   elt.class == self && attrs.symbolize_keys.except(*keys_to_ignore).all? { |k,v| elt.send(k).to_json == v.to_json }
-        # end
-        # if already_pending
-        #   already_pending
-        # else
-        #   to_create = new(attrs)
-
-        #   elements_to_create << to_create
-        #   to_create
-        # end
       end
 
       def self.assign_later(parent:, child:, buffer:)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -392,7 +392,7 @@ module PolicyMachineStorageAdapter
     end
 
     def update_later(element)
-      persistence_elements[:to_upsert][element.unique_identifier] = element
+      buffers[:upsert][element.unique_identifier] = element
     end
 
     ##

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -34,10 +34,6 @@ module PolicyMachineStorageAdapter
       require_relative("active_record/#{PolicyElement.configurations[Rails.env]['adapter']}")
     end
 
-    def self.can_buffer?
-      respond_to?(:persist_buffers!)
-    end
-
     def self.buffering?
       @buffering
     end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -474,7 +474,7 @@ module PolicyMachineStorageAdapter
     end
 
     def bulk_create!
-      PolicyElement.bulk_create!
+      PolicyElement.bulk_persist!
     end
 
     def clear_buffer!

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -132,8 +132,8 @@ module PolicyMachineStorageAdapter
       end
 
       # NB: delete_all in AR bypasses relation logic, which shouldn't matter here.
-      def self.bulk_destroy(buffer)
-        id_groups = buffer.reduce(Hash.new { |h,k| h[k] = [] }) do |memo,(_,el)|
+      def self.bulk_destroy(elements)
+        id_groups = elements.reduce(Hash.new { |h,k| h[k] = [] }) do |memo,(_,el)|
           if el.is_a?(UserAttribute) || el.is_a?(ObjectAttribute)
             memo[el.class] << el.id
           end
@@ -141,8 +141,8 @@ module PolicyMachineStorageAdapter
           memo
         end
 
-        PolicyElement.where(unique_identifier: buffer.keys).delete_all
-        Assignment.where(parent_id: buffer.keys).delete_all
+        PolicyElement.where(unique_identifier: elements.keys).delete_all
+        Assignment.where(parent_id: elements.keys).delete_all
         PolicyElementAssociation.where(user_attribute_id: id_groups[UserAttribute]).delete_all
         PolicyElementAssociation.where(object_attribute_id: id_groups[ObjectAttribute]).delete_all
       end
@@ -338,7 +338,6 @@ module PolicyMachineStorageAdapter
       :buffered
     end
 
-
     ##
     # Determine if there is a path from src to dst in the policy machine.
     # The two policy elements must be persisted policy elements; otherwise the method should raise
@@ -409,7 +408,6 @@ module PolicyMachineStorageAdapter
     #
     def add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
       if self.buffering?
-        #TODO: move to right class
         associate_later(user_attribute, operation_set, object_attribute, policy_machine_uuid)
       else
         PolicyElementAssociation.add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -141,14 +141,14 @@ module PolicyMachineStorageAdapter
         :buffered
       end
 
-      #TODO Are we not using PM UUID here?
+      #TODO PM uuid potentially useful for future optimization, currently unused
       def self.associate_later(user_attribute, operation_set, object_attribute, policy_machine_uuid, buffer)
         buffer << [user_attribute, operation_set, object_attribute, policy_machine_uuid]
       end
 
       # NB: delete_all in AR bypasses relation logic, which shouldn't matter here.
       def self.bulk_destroy(buffer)
-        id_groups = buffer.reduce(Hash.new { [] }) do |memo,(_,el)|
+        id_groups = buffer.reduce(Hash.new { |h,k| h[k] = [] }) do |memo,(_,el)|
           if el.is_a?(UserAttribute) || el.is_a?(ObjectAttribute)
             memo[el.class] << el.id
           end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -133,7 +133,7 @@ module PolicyMachineStorageAdapter
       def self.bulk_create_assignments
         assignments_to_create.map! do |attrs|
           [attrs[:parent].id, attrs[:child].id]
-        end
+        end.uniq!
         Assignment.import([:parent_id, :child_id], assignments_to_create, on_duplicate_key_ignore: true)
       end
 

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -190,6 +190,19 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    #TODO Consider moving into template?
+    def can_buffer?
+      false
+    end
+
+    def self.buffering?
+      false
+    end
+
+    def buffering?
+      false
+    end
+
 
     private
 

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -190,20 +190,6 @@ module PolicyMachineStorageAdapter
       end
     end
 
-    #TODO Consider moving into template?
-    def can_buffer?
-      false
-    end
-
-    def self.buffering?
-      false
-    end
-
-    def buffering?
-      false
-    end
-
-
     private
 
       # Raise argument error if argument is not suitable for consumption in

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('will_paginate')
 
   # Only required in ActiveRecord mode
-  s.add_dependency('activerecord-import', '~> 0.0')
+  s.add_dependency('activerecord-import', '~> 0.12')
     # Only required for mysql
     s.add_dependency('mysql2')
     # Only required for postgres

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -525,8 +525,8 @@ shared_examples "a policy machine" do
 
       # This PM is taken from the policy machine spec, Figure 4. (pg. 19)
       describe "Simple Example:  Figure 4. (pg. 19)#{bulk_create_mode}" do
-        let(:inserts) do
-          lambda do
+        before do
+            inserts = lambda do
             # Users
             @u1 = policy_machine.create_user('u1')
             @u2 = policy_machine.create_user('u2')
@@ -573,10 +573,11 @@ shared_examples "a policy machine" do
             policy_machine.add_association(@group2, Set.new([@w]), @project2)
             policy_machine.add_association(@division, Set.new([@r]), @projects)
           end
-        end
-
-        before do
-          bulk_create_mode ? policy_machine.bulk_persist(&inserts) : inserts.call
+          if bulk_create_mode
+            policy_machine.bulk_persist(&inserts)
+          else
+            inserts.call
+          end
         end
 
         it 'returns all and only these privileges encoded by the policy machine' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -527,7 +527,6 @@ shared_examples "a policy machine" do
       #TODO better cleaner stronger faster tests needed
       describe "Simple Example:  Figure 4. (pg. 19)#{bulk_create_mode}" do
         before do
-          begin
           #Elements for update tests
           default_args = {foo: nil, color: nil}
           @u4 = policy_machine.create_user('u4', default_args)
@@ -622,8 +621,6 @@ shared_examples "a policy machine" do
             policy_machine.bulk_persist(&inserts)
           else
             inserts.call
-          end
-
           end
         end
 

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -574,7 +574,7 @@ shared_examples "a policy machine" do
             policy_machine.add_association(@division, Set.new([@r]), @projects)
           end
           if bulk_create_mode
-            policy_machine.bulk_create(&inserts)
+            policy_machine.bulk_persist(&inserts)
           else
             inserts.call
           end

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -595,7 +595,6 @@ shared_examples "a policy machine" do
 
   describe 'The Mail System:  Figure 8. (pg. 43)' do
     before do
-      policy_machine.bulk_create do
       # Users
       @u2 = policy_machine.create_user('u2')
 
@@ -639,7 +638,6 @@ shared_examples "a policy machine" do
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @out_u2)
       policy_machine.add_association(@id_u2, Set.new([@w]), @inboxes)
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @other_u2)
-      end
     end
 
     it 'returns all and only these privileges encoded by the policy machine' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -521,70 +521,81 @@ shared_examples "a policy machine" do
 
   describe '#privileges' do
 
-    # This PM is taken from the policy machine spec, Figure 4. (pg. 19)
-    describe 'Simple Example:  Figure 4. (pg. 19)' do
-      before do
-        # Users
-        @u1 = policy_machine.create_user('u1')
-        @u2 = policy_machine.create_user('u2')
-        @u3 = policy_machine.create_user('u3')
+    [nil, ' in bulk create mode'].each do |bulk_create_mode|
 
-        # Objects
-        @o1 = policy_machine.create_object('o1')
-        @o2 = policy_machine.create_object('o2')
-        @o3 = policy_machine.create_object('o3')
+      # This PM is taken from the policy machine spec, Figure 4. (pg. 19)
+      describe "Simple Example:  Figure 4. (pg. 19)#{bulk_create_mode}" do
+        before do
+            inserts = lambda do
+            # Users
+            @u1 = policy_machine.create_user('u1')
+            @u2 = policy_machine.create_user('u2')
+            @u3 = policy_machine.create_user('u3')
 
-        # User Attributes
-        @group1 = policy_machine.create_user_attribute('Group1')
-        @group2 = policy_machine.create_user_attribute('Group2')
-        @division = policy_machine.create_user_attribute('Division')
+            # Objects
+            @o1 = policy_machine.create_object('o1')
+            @o2 = policy_machine.create_object('o2')
+            @o3 = policy_machine.create_object('o3')
 
-        # Object Attributes
-        @project1 = policy_machine.create_object_attribute('Project1')
-        @project2 = policy_machine.create_object_attribute('Project2')
-        @projects = policy_machine.create_object_attribute('Projects')
+            # User Attributes
+            @group1 = policy_machine.create_user_attribute('Group1')
+            @group2 = policy_machine.create_user_attribute('Group2')
+            @division = policy_machine.create_user_attribute('Division')
 
-        # Operations
-        @r = policy_machine.create_operation('read')
-        @w = policy_machine.create_operation('write')
+            # Object Attributes
+            @project1 = policy_machine.create_object_attribute('Project1')
+            @project2 = policy_machine.create_object_attribute('Project2')
+            @projects = policy_machine.create_object_attribute('Projects')
 
-        # Policy Classes
-        @ou = policy_machine.create_policy_class("OU")
+            # Operations
+            @r = policy_machine.create_operation('read')
+            @w = policy_machine.create_operation('write')
 
-        # Assignments
-        policy_machine.add_assignment(@u1, @group1)
-        policy_machine.add_assignment(@u2, @group2)
-        policy_machine.add_assignment(@u3, @division)
-        policy_machine.add_assignment(@group1, @division)
-        policy_machine.add_assignment(@group2, @division)
-        policy_machine.add_assignment(@o1, @project1)
-        policy_machine.add_assignment(@o2, @project1)
-        policy_machine.add_assignment(@o3, @project2)
-        policy_machine.add_assignment(@project1, @projects)
-        policy_machine.add_assignment(@project2, @projects)
-        policy_machine.add_assignment(@division, @ou)
-        policy_machine.add_assignment(@projects, @ou)
+            # Policy Classes
+            @ou = policy_machine.create_policy_class("OU")
 
-        # Associations
-        policy_machine.add_association(@group1, Set.new([@w]), @project1)
-        policy_machine.add_association(@group2, Set.new([@w]), @project2)
-        policy_machine.add_association(@division, Set.new([@r]), @projects)
-      end
+            # Assignments
+            policy_machine.add_assignment(@u1, @group1)
+            policy_machine.add_assignment(@u2, @group2)
+            policy_machine.add_assignment(@u3, @division)
+            policy_machine.add_assignment(@group1, @division)
+            policy_machine.add_assignment(@group2, @division)
+            policy_machine.add_assignment(@o1, @project1)
+            policy_machine.add_assignment(@o2, @project1)
+            policy_machine.add_assignment(@o3, @project2)
+            policy_machine.add_assignment(@project1, @projects)
+            policy_machine.add_assignment(@project2, @projects)
+            policy_machine.add_assignment(@division, @ou)
+            policy_machine.add_assignment(@projects, @ou)
 
-      it 'returns all and only these privileges encoded by the policy machine' do
-        expected_privileges = [
-          [@u1, @w, @o1], [@u1, @w, @o2], [@u1, @r, @o1], [@u1, @r, @o2], [@u1, @r, @o3],
-          [@u2, @w, @o3], [@u2, @r, @o1], [@u2, @r, @o2], [@u2, @r, @o3],
-          [@u3, @r, @o1], [@u3, @r, @o2], [@u3, @r, @o3]
-        ]
+            # Associations
+            policy_machine.add_association(@group1, Set.new([@w]), @project1)
+            policy_machine.add_association(@group2, Set.new([@w]), @project2)
+            policy_machine.add_association(@division, Set.new([@r]), @projects)
+          end
+          if bulk_create_mode
+            policy_machine.bulk_create(&inserts)
+          else
+            inserts.call
+          end
+        end
 
-        assert_pm_privilege_expectations(policy_machine.privileges, expected_privileges)
+        it 'returns all and only these privileges encoded by the policy machine' do
+          expected_privileges = [
+            [@u1, @w, @o1], [@u1, @w, @o2], [@u1, @r, @o1], [@u1, @r, @o2], [@u1, @r, @o3],
+            [@u2, @w, @o3], [@u2, @r, @o1], [@u2, @r, @o2], [@u2, @r, @o3],
+            [@u3, @r, @o1], [@u3, @r, @o2], [@u3, @r, @o3]
+          ]
+
+          assert_pm_privilege_expectations(policy_machine.privileges, expected_privileges)
+        end
       end
     end
   end
 
   describe 'The Mail System:  Figure 8. (pg. 43)' do
     before do
+      policy_machine.bulk_create do
       # Users
       @u2 = policy_machine.create_user('u2')
 
@@ -628,6 +639,7 @@ shared_examples "a policy machine" do
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @out_u2)
       policy_machine.add_association(@id_u2, Set.new([@w]), @inboxes)
       policy_machine.add_association(@id_u2, Set.new([@r, @w]), @other_u2)
+      end
     end
 
     it 'returns all and only these privileges encoded by the policy machine' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -525,8 +525,8 @@ shared_examples "a policy machine" do
 
       # This PM is taken from the policy machine spec, Figure 4. (pg. 19)
       describe "Simple Example:  Figure 4. (pg. 19)#{bulk_create_mode}" do
-        before do
-            inserts = lambda do
+        let(:inserts) do
+          lambda do
             # Users
             @u1 = policy_machine.create_user('u1')
             @u2 = policy_machine.create_user('u2')
@@ -573,11 +573,10 @@ shared_examples "a policy machine" do
             policy_machine.add_association(@group2, Set.new([@w]), @project2)
             policy_machine.add_association(@division, Set.new([@r]), @projects)
           end
-          if bulk_create_mode
-            policy_machine.bulk_persist(&inserts)
-          else
-            inserts.call
-          end
+        end
+
+        before do
+          bulk_create_mode ? policy_machine.bulk_persist(&inserts) : inserts.call
         end
 
         it 'returns all and only these privileges encoded by the policy machine' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -524,17 +524,34 @@ shared_examples "a policy machine" do
     [nil, ' in bulk create mode'].each do |bulk_create_mode|
 
       # This PM is taken from the policy machine spec, Figure 4. (pg. 19)
+      #TODO better cleaner stronger faster tests needed
       describe "Simple Example:  Figure 4. (pg. 19)#{bulk_create_mode}" do
         before do
           begin
-          if policy_machine.policy_machine_storage_adapter.class == PolicyMachineStorageAdapter::ActiveRecord
-            @u4 = policy_machine.create_user('u4', {foo: nil})
-            @o4 = policy_machine.create_object('o4', {foo: nil})
-            @preexisting_group = policy_machine.create_user_attribute('preexisting_group', {foo: nil})
-            @preexisting_project = policy_machine.create_object_attribute('preexisting_project', {foo: nil})
-            @preexisting_policy_class = policy_machine.create_policy_class('preexisting_policy_class', {foo: nil})
-            @e = policy_machine.create_operation('edit')
-          end
+          #Elements for update tests
+          default_args = {foo: nil, color: nil}
+          @u4 = policy_machine.create_user('u4', default_args)
+          @o4 = policy_machine.create_object('o4', default_args)
+          @preexisting_group = policy_machine.create_user_attribute('preexisting_group', default_args)
+          @preexisting_project = policy_machine.create_object_attribute('preexisting_project', default_args)
+          @preexisting_policy_class = policy_machine.create_policy_class('preexisting_policy_class', default_args)
+          @e = policy_machine.create_operation('edit')
+
+          # Elements for delete tests
+          @u5 = policy_machine.create_user('u5')
+          @u6 = policy_machine.create_user('u6')
+          @o5 = policy_machine.create_object('o5')
+          @o6 = policy_machine.create_object('o6')
+          @group3 = policy_machine.create_user_attribute('Group3')
+          @project3 = policy_machine.create_object_attribute('Project3')
+
+          # Assignments for delete tests
+          policy_machine.add_assignment(@u5, @group3)
+          policy_machine.add_assignment(@u6, @group3)
+          policy_machine.add_assignment(@group3, @preexisting_policy_class)
+          policy_machine.add_assignment(@o5, @project3)
+          policy_machine.add_assignment(@o6, @project3)
+          policy_machine.add_assignment(@project3, @preexisting_policy_class)
 
           inserts = lambda do
             # Users
@@ -578,28 +595,27 @@ shared_examples "a policy machine" do
             policy_machine.add_assignment(@division, @ou)
             policy_machine.add_assignment(@projects, @ou)
 
-            #Updates for preexsiting objects
-            if policy_machine.policy_machine_storage_adapter.class == PolicyMachineStorageAdapter::ActiveRecord
-              #Assignments for preexisting objects
-              policy_machine.add_assignment(@u4, @preexisting_group)
-              policy_machine.add_assignment(@o4, @preexisting_project)
-              policy_machine.add_assignment(@preexisting_project, @preexisting_policy_class)
-              policy_machine.add_assignment(@preexisting_group, @preexisting_policy_class)
+            #Assignments for preexisting objects
+            policy_machine.add_assignment(@u4, @preexisting_group)
+            policy_machine.add_assignment(@o4, @preexisting_project)
+            policy_machine.add_assignment(@preexisting_project, @preexisting_policy_class)
+            policy_machine.add_assignment(@preexisting_group, @preexisting_policy_class)
 
-              # Updates of preexisting elements
-              @o4.update(foo: 'bar', color: 'purple')
-              @u4.update(foo: 'bar', color: 'purple')
-              @preexisting_group.update(foo: 'bar', color: 'purple')
-              @preexisting_project.update(foo: 'bar', color: 'purple')
+            # Updates of preexisting elements
+            @o4.update(foo: 'bar', color: 'purple')
+            @u4.update(foo: 'bar', color: 'purple')
+            @preexisting_group.update(foo: 'bar', color: 'purple')
+            @preexisting_project.update(foo: 'bar', color: 'purple')
 
-              #Associations for preexisting objects
-              policy_machine.add_association(@preexisting_group, Set.new([@e]), @preexisting_project)
-            end
+            #Associations for preexisting objects
+            policy_machine.add_association(@preexisting_group, Set.new([@e]), @preexisting_project)
 
             # Associations
             policy_machine.add_association(@group1, Set.new([@w]), @project1)
             policy_machine.add_association(@group2, Set.new([@w]), @project2)
             policy_machine.add_association(@division, Set.new([@r]), @projects)
+
+            [@u5, @u6, @o5, @o6, @group3, @project3].each(&:delete)
           end
 
           if bulk_create_mode
@@ -608,8 +624,6 @@ shared_examples "a policy machine" do
             inserts.call
           end
 
-          rescue => e
-            # binding.pry
           end
         end
 
@@ -624,11 +638,17 @@ shared_examples "a policy machine" do
         end
 
         it 'updates policy element attributes appropriately' do
-          if policy_machine.policy_machine_storage_adapter.class == PolicyMachineStorageAdapter::ActiveRecord
-            [@o4, @u4, @preexisting_group, @preexisting_project].each do |el|
-              expect(el.foo).to eq 'bar'
-              expect(el.color).to eq 'purple'
-            end
+          [@o4, @u4, @preexisting_group, @preexisting_project].each do |el|
+            expect(el.foo).to eq 'bar'
+            expect(el.color).to eq 'purple'
+          end
+        end
+
+        it 'deletes appropriate elements' do
+          [@u5, @u6, @o5, @o6, @group3, @project3].each do |el|
+            meth  = el.class.to_s.split("::").last.underscore.pluralize
+            match = policy_machine.send(meth, {unique_identifier: el.unique_identifier})
+            expect(match).to be_empty
           end
         end
       end


### PR DESCRIPTION
This PR, based off of #62, implements buffering at the adapter class level for writes of policy elements, assignments, associations, and deletes.  In the future, we may wish to limit buffering to a specific instance of an adapter for multithreaded usage of the policy machine, but all instances of the policy machine, should they wish to share a buffer, will also need to share the same instance of the policy machine storage adapter.

Regression results:
```
Finished in 37.19 seconds
728 examples, 0 failures, 12 pending
```