### PR TITLE
Fix/bulk json

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -70,9 +70,9 @@ module PolicyMachineStorageAdapter
       # during import, we set all attributes again in bulk here.  It is important
       # that these changes are mutative, since the default ActiveRecord magic
       # being relied on for assignments and associations will break, otherwise
-      buffers[:upsert].values.each { |element| element.attributes = element.attributes.slice(*column_keys) }
+      buffers[:upsert].values.each { |el| el.attributes = el.attributes.slice(*column_keys) }
 
-      PolicyElement.import(elements_to_upsert, on_duplicate_key_update: column_keys.map(&:to_sym) - [:id])
+      PolicyElement.import(buffers[:upsert].values, on_duplicate_key_update: column_keys.map(&:to_sym) - [:id])
       PolicyElement.bulk_destroy(buffers[:delete])
       PolicyElement.bulk_assign(buffers[:assignments])
       PolicyElement.bulk_associate(buffers[:associations])

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -70,10 +70,7 @@ module PolicyMachineStorageAdapter
       # during import, we set all attributes again in bulk here.  It is important
       # that these changes are mutative, since the default ActiveRecord magic
       # being relied on for assignments and associations will break, otherwise
-      elements_to_upsert = buffers[:upsert].values.map do |element|
-        element.attributes =  element.attributes.slice(*column_keys)
-        element
-      end
+      buffers[:upsert].values.each { |element| element.attributes = element.attributes.slice(*column_keys) }
 
       PolicyElement.import(elements_to_upsert, on_duplicate_key_update: column_keys.map(&:to_sym) - [:id])
       PolicyElement.bulk_destroy(buffers[:delete])

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -66,6 +66,10 @@ module PolicyMachineStorageAdapter
     def self.persist_buffers!
       column_keys = PolicyElement.column_names
 
+      # Because activerecord-import cannot yet handle arbitrary serialized values
+      # during import, we set all attributes again in bulk here.  It is important
+      # that these changes are mutative, since the default ActiveRecord magic
+      # being relied on for assignments and associations will break, otherwise
       elements_to_upsert = buffers[:upsert].values.map do |element|
         element.attributes =  element.attributes.slice(*column_keys)
         element

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -624,6 +624,27 @@ shared_examples "a policy machine" do
           end
         end
 
+        PolicyMachine::POLICY_ELEMENT_TYPES.each do |type|
+          let(:document) { {'some' => 'hash'}}
+
+          before do
+            inserts = lambda do
+              policy_machine.send("create_#{type}", SecureRandom.uuid, {document: document})
+            end
+
+            @obj = if bulk_create_mode
+              policy_machine.bulk_persist(&inserts)
+            else
+              inserts.call
+            end
+          end
+
+          it 'persists arbitrary documents correctly' do
+            expect(@obj.document).to eq document
+          end
+        end
+
+
         it 'returns all and only these privileges encoded by the policy machine' do
           expected_privileges = [
             [@u1, @w, @o1], [@u1, @w, @o2], [@u1, @r, @o1], [@u1, @r, @o2], [@u1, @r, @o3],
@@ -648,6 +669,7 @@ shared_examples "a policy machine" do
             expect(match).to be_empty
           end
         end
+
       end
     end
   end


### PR DESCRIPTION
Bulk Insert does not handle 'special' AR insert types (hstore, jsonb, etc) if the AR magic to use attributes delegated to the store is the method used to set them.  This PR escapes that problem by reassigning all attributes at the top level before persistence.  @DMcKinnon-mdsol and @HonoreDB, please review