### PR TITLE
Join on id, not on implicit cast of unique_identifier string

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -149,7 +149,8 @@ module PolicyMachineStorageAdapter
         end
 
         PolicyElement.where(unique_identifier: elements.keys).delete_all
-        Assignment.where(parent_id: elements.keys).delete_all
+        Assignment.where(parent_id: elements.values.flat_map(&:id)).delete_all
+        Assignment.where(child_id: elements.values.flat_map(&:id)).delete_all
         PolicyElementAssociation.where(user_attribute_id: id_groups[UserAttribute]).delete_all
         PolicyElementAssociation.where(object_attribute_id: id_groups[ObjectAttribute]).delete_all
       end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -74,6 +74,25 @@ describe 'ActiveRecord' do
           end
         end
       end
+
+      describe 'bulk_deletion' do
+        it 'deletes only those assignments that were on deleted elements' do
+          @pm = PolicyMachine.new(:name => 'ActiveRecord PM', :storage_adapter => PolicyMachineStorageAdapter::ActiveRecord)
+          @u1 = @pm.create_user('u1')
+          @op = @pm.create_operation('own')
+          @user_attribute = @pm.create_user_attribute('ua1')
+          @object_attribute = @pm.create_object_attribute('oa1')
+          @object = @pm.create_object('o1')
+          @pm.add_assignment(@u1, @user_attribute)
+          @pm.add_association(@user_attribute, Set.new([@op]), @object_attribute)
+          @pm.add_assignment(@object, @object_attribute)
+          expect(@pm.is_privilege?(@u1,@op,@object)).to be
+          @elt = @pm.create_object(@u1.stored_pe.id.to_s)
+          @pm.bulk_persist { @elt.delete }
+          expect(@pm.is_privilege?(@u1,@op,@object)).to be
+        end
+      end
+
     end
 
     describe 'method_missing' do


### PR DESCRIPTION
Specs pass. The bulk cleanup of orphaned assignments got wonky and was referencing the unique_identifier, not the id, of deleted elements. If the unique_identifier happened to be a string starting with a number, this would be cast to that number and would delete random assignments.