### PR TITLE
Remove = from the attribute key

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -97,7 +97,7 @@ module PolicyMachineStorageAdapter
         if respond_to?(meth)
           send(meth, *args)
         elsif meth.to_s[-1] == '='
-          @extra_attributes_hash[meth.to_s] = args.first
+          @extra_attributes_hash[meth.to_s.chop] = args.first
         else
           super
         end


### PR DESCRIPTION
As promised, a fix using psychic powers since we can't repro this locally. What I think was going down: we hit method_missing when trying to set a new attribute having never previously referenced it, and the affected code erroneously treats "foo=" as the attribute name. Then, another code path hits `store_attributes` again, and that key becomes a methodized attribute name. Then we try to set `foo=` again, and this time it's defined as an arity-0 getter instead of an arity 1 setter.

Specs pass.