### PR TITLE
Fix abstraction layer skip in batch find

### DIFF
--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -63,7 +63,7 @@ module PM
     end
 
     # Converts a stored_pe to an instantiated pe
-    def self.convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, pe_class)
+    def self.convert_stored_pe_to_pe(stored_pe, pm_storage_adapter, pe_class = self)
       pe_class.new(
         stored_pe.unique_identifier,
         stored_pe.policy_machine_uuid,

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -917,6 +917,7 @@ shared_examples "a policy machine" do
           policy_machine.batch_find(type: :object, query: { unique_identifier: 'one:fish' }) do |batch|
             expect(batch.size).to eq 1
             expect(batch.first.unique_identifier).to eq 'one:fish'
+            expect(batch.first).to be_a(PM::Object)
           end
         end
       end


### PR DESCRIPTION
The regular finds go through the PolicyElement classes, which wrap the results of the underlying storage engine. The batch finds bypass this to go right to the storage adapter. This usually doesn't have much effect due to duck typing, but means we miss some methods only provided in the wrapper. This PR puts the wrapper back.