### PR TITLE
Don't spam the same warning repeatedly within a single process

### DIFF
--- a/lib/policy_machine/warn_once.rb
+++ b/lib/policy_machine/warn_once.rb
@@ -1,0 +1,14 @@
+require 'set'
+
+class Warn
+
+  @displayed_warnings = Set.new
+
+  def self.once(string, *interpolated_values)
+    if @displayed_warnings.add?(string)
+      string %= interpolated_values if interpolated_values.any?
+      warn(string)
+    end
+  end
+
+end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -1,5 +1,6 @@
 require 'policy_machine'
 require 'set'
+require 'policy_machine/warn_once'
 
 # This class stores policy elements in a SQL database using whatever
 # database configuration and adapters are provided by active_record.
@@ -322,9 +323,9 @@ module PolicyMachineStorageAdapter
         end
 
         extra_attribute_conditions.each do |key, value|
-          warn "WARNING: #{self.class} is filtering #{pe_type} on #{key} in memory, which won't scale well. " <<
+          Warn.once("WARNING: #{self.class} is filtering #{pe_type} on #{key} in memory, which won't scale well. " <<
             "To move this query to the database, add a '#{key}' column to the policy_elements table " <<
-            "and re-save existing records"
+            "and re-save existing records")
             all.to_a.select!{ |pe| pe.store_attributes and
                         ((attr_value = pe.extra_attributes_hash[key]).is_a?(String) and
                         value.is_a?(String) and ignore_case_applies?(options[:ignore_case],key)) ? attr_value.downcase == value.downcase : attr_value == value}

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -27,15 +27,17 @@ describe 'ActiveRecord' do
 
     describe 'find_all_of_type' do
 
-      it 'warns when filtering on an extra attribute' do
-        policy_machine_storage_adapter.should_receive(:warn).once
-        policy_machine_storage_adapter.find_all_of_type_user(foo: 'bar').should be_empty
+      it 'warns once when filtering on an extra attribute' do
+        Warn.should_receive(:warn).once
+        2.times do
+          policy_machine_storage_adapter.find_all_of_type_user(foo: 'bar').should be_empty
+        end
       end
 
       context 'an extra attribute column has been added to the database' do
 
         it 'does not warn' do
-          policy_machine_storage_adapter.should_not_receive(:warn)
+          Warn.should_not_receive(:warn)
           policy_machine_storage_adapter.find_all_of_type_user(color: 'red').should be_empty
         end
 


### PR DESCRIPTION
While we're here. I'm not taking out the warning entirely, because it's legitimate (old man shakes fist at clouds), but no reason to fill up sumo and rspec logs with it.