### PR TITLE
Pluck virtual attributes

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -375,10 +375,10 @@ module PolicyMachineStorageAdapter
 
         # Fields must include a primary key to avoid ActiveRecord errors
         fields << :id
-        if extras = extra_attribute_fields(all.first, fields)
-          fields = fields - extras
-          fields << :extra_attributes
+        if extras = extra_attributes_to_pluck(all.first, fields)
+          fields = fields - extras + [:extra_attributes]
         end
+
         all.select(*fields)
       end
     end # End of POLICY_ELEMENT_TYPES iteration
@@ -407,7 +407,7 @@ module PolicyMachineStorageAdapter
       end
     end
 
-    def extra_attribute_fields(policy_element, fields)
+    def extra_attributes_to_pluck(policy_element, fields)
       extras = policy_element.extra_attributes_hash.symbolize_keys
       fields.select { |field| extras.include?(field) }
     end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -370,9 +370,16 @@ module PolicyMachineStorageAdapter
       end
 
       define_method("pluck_all_of_type_#{pe_type}") do |fields:, options: {}|
+        all = method("find_all_of_type_#{pe_type}").call(options)
+        return unless all.present?
+
         # Fields must include a primary key to avoid ActiveRecord errors
         fields << :id
-        method("find_all_of_type_#{pe_type}").call(options).select(*fields)
+        if extras = extra_attribute_fields(all.first, fields)
+          fields = fields - extras
+          fields << :extra_attributes
+        end
+        all.select(*fields)
       end
     end # End of POLICY_ELEMENT_TYPES iteration
 
@@ -398,6 +405,11 @@ module PolicyMachineStorageAdapter
           attr_value == value
         end
       end
+    end
+
+    def extra_attribute_fields(policy_element, fields)
+      extras = policy_element.extra_attributes.symbolize_keys
+      fields.select { |field| extras.include?(field) }
     end
 
     # Allow ignore_case to be a boolean, string, symbol, or array of symbols or strings

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -408,7 +408,7 @@ module PolicyMachineStorageAdapter
     end
 
     def extra_attribute_fields(policy_element, fields)
-      extras = policy_element.extra_attributes.symbolize_keys
+      extras = policy_element.extra_attributes_hash.symbolize_keys
       fields.select { |field| extras.include?(field) }
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -408,7 +408,7 @@ module PolicyMachineStorageAdapter
     end
 
     def extra_attributes_to_pluck(policy_element, fields)
-      extras = policy_element.extra_attributes_hash.symbolize_keys
+      extras = policy_element.extra_attributes.symbolize_keys
       fields.select { |field| extras.include?(field) }
     end
 

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1180,7 +1180,7 @@ shared_examples "a policy machine" do
       @one_fish = policy_machine.create_object('one:fish')
       @two_fish = policy_machine.create_object('two:fish')
       @red_one = policy_machine.create_object('red:one')
-      @blue_one = policy_machine.create_object('blue:one', { color: 'blue' })
+      @blue_one = policy_machine.create_object('blue:one', color: 'blue')
       @read = policy_machine.create_operation('read')
       @write = policy_machine.create_operation('write')
       @u1 = policy_machine.create_user('u1')
@@ -1207,6 +1207,15 @@ shared_examples "a policy machine" do
           policy_machine.batch_pluck(type: :object, query: { unique_identifier: 'one:fish' }, fields: [:unique_identifier]) do |batch|
             expect(batch.size).to eq 1
             expect(batch.first.unique_identifier).to eq 'one:fish'
+          end
+        end
+
+        it 'returns matching extra_attributes' do
+          @extra_one = policy_machine.create_user('sam_i_am', status: 'extraneous')
+
+          policy_machine.batch_pluck(type: :user, query: { unique_identifier: 'sam_i_am' }, fields: [:status]) do |batch|
+            expect(batch.size).to eq 1
+            expect(batch.first.status).to eq 'extraneous'
           end
         end
 

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1213,9 +1213,10 @@ shared_examples "a policy machine" do
         it 'returns matching extra_attributes' do
           @extra_one = policy_machine.create_user('sam_i_am', status: 'extraneous')
 
-          policy_machine.batch_pluck(type: :user, query: { unique_identifier: 'sam_i_am' }, fields: [:status]) do |batch|
+          policy_machine.batch_pluck(type: :user, query: { unique_identifier: 'sam_i_am' }, fields: [:unique_identifier, :status]) do |batch|
             expect(batch.size).to eq 1
             expect(batch.first.status).to eq 'extraneous'
+            expect(batch.first.unique_identifier).to eq 'sam_i_am'
           end
         end
 


### PR DESCRIPTION
A brief implementation of `pluck_all_in_batches` supporting virtual attribute queries. 

Current method is to 
1. Intercept plucks with `fields` arguments that are extra_attributes
2. Remove the offending fields and replace them with `:extra_attributes`
3. Perform the `ActiveRecord::Relation.select` as normal
4. ???

The return value, if it contains _any_ extra_attributes, will contain _all_ of the extra_attributes. Alternately, there could be a step 4 which reverses the shell game and substitutes the original fields back into the return value.

Opened for discussion and alternate methodology. @mdsol/team04 