### PR TITLE
[MCC-288395] Standardize batch_pluck response

### DIFF
--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -638,7 +638,9 @@ module PolicyMachineStorageAdapter
 
     def batch_pluck(policy_object, query: {}, fields:, config: {}, &blk)
       raise(ArgumentError, "must provide fields to pluck") unless fields.present?
-      method("pluck_all_of_type_#{policy_object}").call(fields: fields, options: query).find_in_batches(config, &blk)
+      method("pluck_all_of_type_#{policy_object}").call(fields: fields, options: query).find_in_batches(config) do |batch|
+        yield batch.map { |elt| elt.attributes.symbolize_keys }
+      end
     end
 
     ## Optimized version of PolicyMachine#accessible_objects

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1181,17 +1181,6 @@ shared_examples "a policy machine" do
       @two_fish = policy_machine.create_object('two:fish')
       @red_one = policy_machine.create_object('red:one')
       @blue_one = policy_machine.create_object('blue:one', { color: 'blue' })
-      @read = policy_machine.create_operation('read')
-      @write = policy_machine.create_operation('write')
-      @u1 = policy_machine.create_user('u1')
-      @ua = policy_machine.create_user_attribute('ua')
-      [@one_fish, @two_fish, @red_one].each do |object|
-        policy_machine.add_association(@ua, Set.new([@read]), object)
-      end
-      @oa = policy_machine.create_object_attribute('oa')
-      policy_machine.add_association(@ua, Set.new([@write]), @oa)
-      policy_machine.add_assignment(@u1, @ua)
-      policy_machine.add_assignment(@red_one, @oa)
     end
 
     context 'when given a block' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1214,7 +1214,7 @@ shared_examples "a policy machine" do
           policy_machine.batch_pluck(type: :object, query: { unique_identifier: 'blue:one' }, fields: [:color]) do |batch|
             expect(batch.size).to eq 1
             expect(batch.first[:color]).to eq 'blue'
-            expect(batch.first[:unique_identifier]).to be nil
+            expect(batch.first).not_to have_key(:unique_identifier)
           end
         end
       end

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1206,15 +1206,15 @@ shared_examples "a policy machine" do
         it 'returns the matching attributes' do
           policy_machine.batch_pluck(type: :object, query: { unique_identifier: 'one:fish' }, fields: [:unique_identifier]) do |batch|
             expect(batch.size).to eq 1
-            expect(batch.first.unique_identifier).to eq 'one:fish'
+            expect(batch.first[:unique_identifier]).to eq 'one:fish'
           end
         end
 
         it 'does not return non-specified attributes' do
           policy_machine.batch_pluck(type: :object, query: { unique_identifier: 'blue:one' }, fields: [:color]) do |batch|
             expect(batch.size).to eq 1
-            expect(batch.first.color).to eq 'blue'
-            expect(batch.first.respond_to?(:unique_identifier)).to be false
+            expect(batch.first[:color]).to eq 'blue'
+            expect(batch.first[:unique_identifier]).to be nil
           end
         end
       end
@@ -1242,7 +1242,7 @@ shared_examples "a policy machine" do
       it 'the results are chainable and returns the relevant results' do
         enum = policy_machine.batch_pluck(type: :object, fields: [:unique_identifier])
         results = enum.flat_map do |batch|
-          batch.map { |pe| pe.unique_identifier }
+          batch.map { |pe| pe[:unique_identifier] }
         end
         expected = %w(one:fish two:fish red:one)
         expect(results).to include(*expected)
@@ -1252,7 +1252,7 @@ shared_examples "a policy machine" do
         it 'the results are chainable and returns the relevant results' do
           enum = policy_machine.batch_pluck(type: :object, query: { unique_identifier: 'one:fish' }, fields: [:unique_identifier])
         results = enum.flat_map do |batch|
-          batch.map { |pe| pe.unique_identifier }
+          batch.map { |pe| pe[:unique_identifier] }
         end
           expected = 'one:fish'
           expect(results.first).to eq(expected)
@@ -1264,7 +1264,7 @@ shared_examples "a policy machine" do
           enum = policy_machine.batch_pluck(type: :object, fields: [:unique_identifier], config: { batch_size: 4 })
           results = enum.flat_map do |batch|
             expect(batch.size).to eq 4
-            batch.map { |pe| pe.unique_identifier }
+            batch.map { |pe| pe[:unique_identifier] }
           end
           expected = %w(one:fish two:fish red:one)
           expect(results).to include(*expected)


### PR DESCRIPTION
This PR standardizes the response of `batch_pluck`; it now returns an array of symbolic hashes. This is cheaper than creating a struct for each returned element, and matches the format of the input (an array of symbols, representing fields-to-pluck).

Virtual attributes are still not supported for the AR adapter.

@mdsol/team04 please review.