### PR TITLE
[MCC-291327] Retry find_or_create on index uniqueness violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.4.2
-* Fix the ActiveRecord Adapter to retry on `find_or_create` uniqueness violations.
+* Fix the ActiveRecord Adapter to use upserts instead of find or creates.
 
 ## 1.4.1
 * Standardized the return value of batch_pluck.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.2
+* Fix the ActiveRecord Adapter to retry on `find_or_create` uniqueness violations.
+
 ## 1.4.1
 * Standardized the return value of batch_pluck.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.4.2
-* Fix the ActiveRecord Adapter to use upserts instead of find or creates.
+* Update the ActiveRecord Adapter to use upserts instead of first or creates for Assignments.
 
 ## 1.4.1
 * Standardized the return value of batch_pluck.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ By default, the above command will configure the test database to be postgresql,
 bundle exec rake pm:test:prepare[mysql]
 ```
 
+If this command fails with:
+```
+PG::ConnectionBad: could not connect to server: No such file or directory
+```
+Or a similar error, then try adding `localhost` to the test app's database.yml. Namely, navigate to `test/testapp/config/database.yml`, and in the `default` section add a `host` key with the value `localhost` and rerun the above command.
+
 If nokogiri fails to install for the test app, then try installing it specifying your local system libraries like:
 ```
 gem install nokogiri --use-system-libraries

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -207,16 +207,12 @@ module PM
     end
 
     def self.find_or_create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes = {}, prohibition = false)
-      tries ||= 1
       op = pm_storage_adapter.find_all_of_type_operation(unique_identifier: unique_identifier, policy_machine_uuid: policy_machine_uuid).first
       if op
         convert_stored_pe_to_pe(op, pm_storage_adapter, self)
       else
         create(unique_identifier, policy_machine_uuid, pm_storage_adapter, extra_attributes, prohibition)
       end
-    rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation
-      tries += 1
-      tries < 3 ? retry : raise
     end
 
     def to_s
@@ -255,12 +251,13 @@ module PM
       negation = "~#{operation}"
       case operation
       when PM::Operation
-        params = [negation, operation.policy_machine_uuid, operation.pm_storage_adapter, extra_attributes, true]
-        begin
-          PM::Operation.find_or_create(*params)
-        rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation => e
-          find(params) || raise("Could not find record for #{params}, but creating it raised #{e.inspect}")
-        end
+        PM::Operation.find_or_create(
+          negation,
+          operation.policy_machine_uuid,
+          operation.pm_storage_adapter,
+          extra_attributes,
+          true
+        )
       when Symbol
         negation.to_sym
       when String

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 module PolicyMachine
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -286,7 +286,10 @@ module PolicyMachineStorageAdapter
       end
 
       def self.add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
-        where(user_attribute_id: user_attribute.id, object_attribute_id: object_attribute.id).first_or_create.operations = operation_set.to_a
+        where(
+          user_attribute_id: user_attribute.id,
+          object_attribute_id: object_attribute.id
+        ).first_or_create.operations = operation_set.to_a
       end
 
     end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -286,10 +286,9 @@ module PolicyMachineStorageAdapter
       end
 
       def self.add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
-        import([:user_attribute_id, :object_attribute_id], [[user_attribute.id, object_attribute.id]], on_duplicate_key_ignore: true)
-        assoc = find_by_user_attribute_id_and_object_attribute_id(user_attribute.id, object_attribute.id)
-        assoc.operations = operation_set.to_a if assoc
+        where(user_attribute_id: user_attribute.id, object_attribute_id: object_attribute.id).first_or_create.operations = operation_set.to_a
       end
+
     end
 
     class OperationsPolicyElementAssociation < ::ActiveRecord::Base
@@ -433,9 +432,11 @@ module PolicyMachineStorageAdapter
       if self.buffering?
         link_later(parent: src, child: dst)
       else
-        fields = [:link_parent_id, :link_child_id, :link_parent_policy_machine_uuid, :link_child_policy_machine_uuid]
-        values = [[src.id, dst.id, src.policy_machine_uuid, dst.policy_machine_uuid]]
-        LogicalLink.import(fields, values, on_duplicate_key_ignore: true)
+        LogicalLink.import(
+          [:link_parent_id, :link_child_id, :link_parent_policy_machine_uuid, :link_child_policy_machine_uuid],
+          [[src.id, dst.id, src.policy_machine_uuid, dst.policy_machine_uuid]],
+          on_duplicate_key_ignore: true
+        )
       end
     end
 


### PR DESCRIPTION
@jlo188 Noticed that we're receiving quite a few `PG::UniqueViolation` errors in all environments. I traced this back to [AR's find_or_create method not being atomic](http://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by). 

@mdsol/team-04 please review.