### PR TITLE
Fix/ruby 24 specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.4.0
   - 2.2.3
 env:
   global:

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -239,7 +239,7 @@ class PolicyMachine
     if policy_machine_storage_adapter.respond_to?(:batch_pluck)
       policy_machine_storage_adapter.batch_pluck(type, query: query, fields: fields, config: config, &blk)
     else
-      Warn.once("WARNING: batch_pluck is not implemented for storage adapter #{policy_machine_storage_adapter}")
+      Warn.once("WARNING: batch_pluck is not implemented for storage adapter #{policy_machine_storage_adapter.class}")
       results = batch_find(type: type, query: query, config: config) do |batch|
         yield batch.map { |elt| convert_pe_to_fields(elt, fields) }
       end

--- a/spec/policy_machine/association_spec.rb
+++ b/spec/policy_machine/association_spec.rb
@@ -38,7 +38,7 @@ describe PM::Association do
 
     it 'raises when second argument is a set in which at least one element is not a PM::Operation' do
       expect{ PM::Association.create(@user_attribute, Set.new([@operation1, 1]), @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
-        to raise_error(ArgumentError, "expected 1 to be PM::Operation; got Fixnum")
+        to raise_error(ArgumentError, "expected 1 to be PM::Operation; got #{SmallNumber}")
     end
 
     it 'raises when second argument is a set in which at least one element is a PM::Operation which is in a different policy machine' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ $LOAD_PATH.uniq!
 
 require 'policy_machine'
 
+SmallNumber = 3.class #Integer in 2.4, Fixnum before that
+
 Dir["./spec/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -80,7 +80,7 @@ shared_examples "a policy machine" do
       it 'raises when first argument is not a policy element' do
         pe = policy_machine.create_user_attribute(SecureRandom.uuid)
         expect{ policy_machine.add_assignment(1, pe) }
-          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
+          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got #{SmallNumber} instead")
       end
 
       it 'raises when first argument is not in policy machine' do
@@ -123,7 +123,7 @@ shared_examples "a policy machine" do
 
       it 'raises when first argument is not a policy element' do
         expect{ policy_machine.add_assignment(1, @pe1) }
-          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
+          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got #{SmallNumber} instead")
       end
 
       it 'raises when first argument is not in policy machine' do
@@ -180,12 +180,12 @@ shared_examples "a policy machine" do
       end
 
       it 'raises when the first argument is not a policy element' do
-        err_msg = 'args must each be a kind of PolicyElement; got a Fixnum and PM::UserAttribute instead'
+        err_msg = "args must each be a kind of PolicyElement; got a #{SmallNumber} and PM::UserAttribute instead"
         expect{ pm1.add_link(1, pe1) }.to raise_error(ArgumentError, err_msg)
       end
 
       it 'raises when the second argument is not a policy element' do
-        err_msg = 'args must each be a kind of PolicyElement; got a PM::UserAttribute and Fixnum instead'
+        err_msg = "args must each be a kind of PolicyElement; got a PM::UserAttribute and #{SmallNumber} instead"
         expect{ pm1.add_link(pe1, 1) }.to raise_error(ArgumentError, err_msg)
       end
 
@@ -209,7 +209,7 @@ shared_examples "a policy machine" do
       end
 
       it 'raises when first argument is not a policy element' do
-        err_msg = 'args must each be a kind of PolicyElement; got a Fixnum and PM::UserAttribute instead'
+        err_msg = "args must each be a kind of PolicyElement; got a #{SmallNumber} and PM::UserAttribute instead"
         expect{ pm1.add_link(1, pe1) }.to raise_error(ArgumentError, err_msg)
       end
 
@@ -260,12 +260,12 @@ shared_examples "a policy machine" do
         end
 
         it 'raises when the first argument is not a policy element' do
-          err_msg = 'args must each be a kind of PolicyElement; got a Fixnum and PM::UserAttribute instead'
+          err_msg = "args must each be a kind of PolicyElement; got a #{SmallNumber} and PM::UserAttribute instead"
           expect{ pm1.bulk_persist { pm1.add_link(1, pe1) } }.to raise_error(ArgumentError, err_msg)
         end
 
         it 'raises when the second argument is not a policy element' do
-          err_msg = 'args must each be a kind of PolicyElement; got a PM::UserAttribute and Fixnum instead'
+          err_msg = "args must each be a kind of PolicyElement; got a PM::UserAttribute and #{SmallNumber} instead"
           expect{ pm1.bulk_persist { pm1.add_link(pe1, 1) } }.to raise_error(ArgumentError, err_msg)
         end
 
@@ -305,7 +305,7 @@ shared_examples "a policy machine" do
         end
 
         it 'raises when first argument is not a policy element' do
-          err_msg = 'args must each be a kind of PolicyElement; got a Fixnum and PM::UserAttribute instead'
+          err_msg = "args must each be a kind of PolicyElement; got a #{SmallNumber} and PM::UserAttribute instead"
           expect{ pm1.bulk_persist { pm1.add_link(1, pe1) } }.to raise_error(ArgumentError, err_msg)
         end
 
@@ -346,7 +346,7 @@ shared_examples "a policy machine" do
 
       it 'raises when third argument is not a PolicyElement' do
         expect{ policy_machine.add_association(@user_attribute, @operation_set, 3) }
-          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
+          .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got #{SmallNumber} instead")
       end
 
       it 'raises when third argument is not in policy machine' do
@@ -579,7 +579,7 @@ shared_examples "a policy machine" do
       describe 'associations' do
         it 'raises unless options[:associations] is an Array' do
           expect{ policy_machine.is_privilege?(@u1, @w, @o2, :associations => 4) }.
-            to raise_error(ArgumentError, "expected options[:associations] to be an Array; got Fixnum")
+            to raise_error(ArgumentError, "expected options[:associations] to be an Array; got #{SmallNumber}")
         end
 
         it 'raises if options[:associations] is an empty array' do
@@ -621,7 +621,7 @@ shared_examples "a policy machine" do
       describe 'in_user_attribute' do
         it 'raises unless options[:in_user_attribute] is a PM::UserAttribute' do
           expect{ policy_machine.is_privilege?(@u1, @w, @o2, :in_user_attribute => 4) }.
-            to raise_error(ArgumentError, 'expected options[:in_user_attribute] to be a PM::UserAttribute; got Fixnum')
+            to raise_error(ArgumentError, "expected options[:in_user_attribute] to be a PM::UserAttribute; got #{SmallNumber}")
         end
 
         it 'accepts in_user_attribute in options[:in_user_attribute]' do
@@ -641,7 +641,7 @@ shared_examples "a policy machine" do
       describe 'in_object_attribute' do
         it 'raises unless options[:in_object_attribute] is a PM::ObjectAttribute' do
           expect{ policy_machine.is_privilege?(@u1, @w, @o2, :in_object_attribute => 4) }.
-            to raise_error(ArgumentError, 'expected options[:in_object_attribute] to be a PM::ObjectAttribute; got Fixnum')
+            to raise_error(ArgumentError, "expected options[:in_object_attribute] to be a PM::ObjectAttribute; got #{SmallNumber}")
         end
 
         it 'accepts in_object_attribute in options[:in_object_attribute]' do


### PR DESCRIPTION
The Policy Machine does type checking. A lot.

Ruby 2.4 changes the type of numbers from `Fixnum/Bignum < Integer` to just `Integer`.

That change breaks assertions in specs testing the error message returned by typechecking.

This PR fixes those specs.