### PR TITLE
[MCC-276230] Feature/operation set

### DIFF
--- a/lib/generators/the_policy_machine/update_policy_element_associations_table_generator.rb
+++ b/lib/generators/the_policy_machine/update_policy_element_associations_table_generator.rb
@@ -1,0 +1,12 @@
+module ThePolicyMachine
+  module Generators
+    class UpdatePolicyElementAssociationsTableGenerator < Rails::Generators::Base
+      source_root File.expand_path('../../../migrations', __FILE__)
+
+      def generate_add_logical_links_table_migration
+        timestamp = Time.now.utc.strftime("%Y%m%d%H%M%S")
+        copy_file('add_logical_links_table.rb', "db/migrate/#{timestamp}_update_policy_elment_associations_table.rb")
+      end
+    end
+  end
+end

--- a/lib/generators/the_policy_machine/update_policy_element_associations_table_generator.rb
+++ b/lib/generators/the_policy_machine/update_policy_element_associations_table_generator.rb
@@ -3,7 +3,7 @@ module ThePolicyMachine
     class UpdatePolicyElementAssociationsTableGenerator < Rails::Generators::Base
       source_root File.expand_path('../../../migrations', __FILE__)
 
-      def generate_add_logical_links_table_migration
+      def generate_update_policy_element_association_table_migration
         timestamp = Time.now.utc.strftime("%Y%m%d%H%M%S")
         copy_file('update_policy_element_associations_table.rb', "db/migrate/#{timestamp}_update_policy_element_associations_table.rb")
       end

--- a/lib/generators/the_policy_machine/update_policy_element_associations_table_generator.rb
+++ b/lib/generators/the_policy_machine/update_policy_element_associations_table_generator.rb
@@ -5,7 +5,7 @@ module ThePolicyMachine
 
       def generate_add_logical_links_table_migration
         timestamp = Time.now.utc.strftime("%Y%m%d%H%M%S")
-        copy_file('add_logical_links_table.rb', "db/migrate/#{timestamp}_update_policy_elment_associations_table.rb")
+        copy_file('update_policy_element_associations_table.rb', "db/migrate/#{timestamp}_update_policy_element_associations_table.rb")
       end
     end
   end

--- a/lib/migrations/update_policy_element_associations_table.rb
+++ b/lib/migrations/update_policy_element_associations_table.rb
@@ -1,0 +1,5 @@
+class UpdatePolicyElementAssociationsTable < ActiveRecord::Migration
+  def change
+    add_column :policy_element_associations, :operation_set_id, :integer
+  end
+end

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'policy_machine/policy_element'
 require 'policy_machine/association'
 require 'policy_machine/warn_once'
@@ -69,15 +70,15 @@ class PolicyMachine
   end
 
   ##
-  # Add an association between a user_attribute, an operation_set and an object_attribute
+  # Add an association between a user_attribute, an set_of_operation_objects and an object_attribute
   # in this policy machine.
   #
-  def add_association(user_attribute_pe, operation_set, object_attribute_pe)
+  def add_association(user_attribute_pe, set_of_operation_objects, object_attribute_pe)
     assert_policy_element_in_machine(user_attribute_pe)
-    operation_set.each{ |op| assert_policy_element_in_machine(op) }
+    set_of_operation_objects.each{ |op| assert_policy_element_in_machine(op) }
     assert_policy_element_in_machine(object_attribute_pe)
 
-    PM::Association.create(user_attribute_pe, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter)
+    PM::Association.create(user_attribute_pe, set_of_operation_objects, object_attribute_pe, @uuid, @policy_machine_storage_adapter)
   end
 
   ##
@@ -362,7 +363,7 @@ class PolicyMachine
 
   # According to the NIST spec:  "the triple (u, op, o) is a privilege, iff there
   # exists an association (ua, ops, oa), such that user u→+ua, op ∈ ops, and o→*oa."
-  # Note:  this method assumes that the caller has already checked that the given operation is in the operation_set
+  # Note:  this method assumes that the caller has already checked that the given operation is in the set_of_operation_objects
   # for all associations provided.
   def is_privilege_single_policy_class(user_or_attribute, object_or_attribute, associations)
     # does there exist an association (ua, ops, oa), such that user u→+ua, op ∈ ops, and o→*oa?
@@ -374,7 +375,7 @@ class PolicyMachine
   # According to the NIST spec:  "In multiple policy class situations, the triple (u, op, o) is a PM privilege, iff for
   # each policy class pcl that contains o, there exists an association (uai, opsj, oak),
   # such that user u→+uai, op ∈ opsj, o→*oak, and oak→+pcl."
-  # Note:  this method assumes that the caller has already checked that the given operation is in the operation_set
+  # Note:  this method assumes that the caller has already checked that the given operation is in the set_of_operation_objects
   # for all associations provided.
   def is_privilege_multiple_policy_classes(user_or_attribute, object_or_attribute, associations, policy_classes_containing_object)
     policy_classes_containing_object.all? do |pc|

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -75,7 +75,7 @@ class PolicyMachine
   #
   def add_association(user_attribute_pe, set_of_operation_objects, operation_set, object_attribute_pe)
     assert_policy_element_in_machine(user_attribute_pe)
-    set_of_operation_objects.each{ |op| assert_policy_element_in_machine(op) }
+    set_of_operation_objects.each { |op| assert_policy_element_in_machine(op) }
     assert_policy_element_in_machine(object_attribute_pe)
     assert_policy_element_in_machine(operation_set)
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -70,7 +70,7 @@ class PolicyMachine
   end
 
   ##
-  # Add an association between a user_attribute, an set_of_operation_objects and an object_attribute
+  # Add an association between a user_attribute, a set_of_operation_objects and an object_attribute
   # in this policy machine.
   #
   def add_association(user_attribute_pe, set_of_operation_objects, operation_set, object_attribute_pe)

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -11,7 +11,7 @@ require 'will_paginate/array'
 Dir.glob(File.dirname(File.absolute_path(__FILE__)) + '/policy_machine_storage_adapters/*.rb').each{ |f| require f }
 
 class PolicyMachine
-  POLICY_ELEMENT_TYPES = %w(user user_attribute object object_attribute operation policy_class)
+  POLICY_ELEMENT_TYPES = %w(user user_attribute object object_attribute operation operation_set policy_class)
 
   attr_accessor :name
   attr_reader   :uuid
@@ -73,12 +73,13 @@ class PolicyMachine
   # Add an association between a user_attribute, an set_of_operation_objects and an object_attribute
   # in this policy machine.
   #
-  def add_association(user_attribute_pe, set_of_operation_objects, object_attribute_pe)
+  def add_association(user_attribute_pe, set_of_operation_objects, operation_set, object_attribute_pe)
     assert_policy_element_in_machine(user_attribute_pe)
     set_of_operation_objects.each{ |op| assert_policy_element_in_machine(op) }
     assert_policy_element_in_machine(object_attribute_pe)
+    assert_policy_element_in_machine(operation_set)
 
-    PM::Association.create(user_attribute_pe, set_of_operation_objects, object_attribute_pe, @uuid, @policy_machine_storage_adapter)
+    PM::Association.create(user_attribute_pe, set_of_operation_objects, operation_set, object_attribute_pe, @uuid, @policy_machine_storage_adapter)
   end
 
   ##

--- a/lib/policy_machine/association.rb
+++ b/lib/policy_machine/association.rb
@@ -39,7 +39,7 @@ module PM
     #
     def includes_operation?(operation)
       # Note:  set_of_operation_objects.member? isn't calling PM::PolicyElement ==
-      set_of_operation_objects.any?{ |op| op == operation }
+      set_of_operation_objects.any? { |op| op == operation }
     end
 
     # Create an association given persisted policy elements

--- a/lib/policy_machine/association.rb
+++ b/lib/policy_machine/association.rb
@@ -1,24 +1,25 @@
 module PM
   class Association
     attr_accessor :user_attribute
-    attr_accessor :operation_set
+    attr_accessor :set_of_operation_objects
+    # attr_accessor :operation_set
     attr_accessor :object_attribute
 
-    def initialize(stored_user_attribute, stored_operation_set, stored_object_attribute, pm_storage_adapter)
+    def initialize(stored_user_attribute, stored_set_of_operation_objects, stored_object_attribute, pm_storage_adapter)
       @user_attribute = PM::PolicyElement.convert_stored_pe_to_pe(
         stored_user_attribute,
         pm_storage_adapter,
         PM::UserAttribute
       )
 
-      @operation_set = Set.new
-      stored_operation_set.each do |stored_op|
+      @set_of_operation_objects = Set.new
+      stored_set_of_operation_objects.each do |stored_op|
         op = PM::PolicyElement.convert_stored_pe_to_pe(
           stored_op,
           pm_storage_adapter,
           PM::Operation
         )
-        @operation_set << op
+        @set_of_operation_objects << op
       end
 
       @object_attribute = PM::PolicyElement.convert_stored_pe_to_pe(
@@ -31,23 +32,23 @@ module PM
     # Returns true if the operation set of this association includes the given operation.
     #
     def includes_operation?(operation)
-      # Note:  operation_set.member? isn't calling PM::PolicyElement ==
-      operation_set.any?{ |op| op == operation }
+      # Note:  set_of_operation_objects.member? isn't calling PM::PolicyElement ==
+      set_of_operation_objects.any?{ |op| op == operation }
     end
 
     # Create an association given persisted policy elements
     #
-    def self.create(user_attribute_pe, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter)
+    def self.create(user_attribute_pe, set_of_operation_objects, object_attribute_pe, policy_machine_uuid, pm_storage_adapter)
       # argument errors for user_attribute_pe
       raise(ArgumentError, "user_attribute_pe must be a UserAttribute.") unless user_attribute_pe.is_a?(PM::UserAttribute)
       unless user_attribute_pe.policy_machine_uuid == policy_machine_uuid
         raise(ArgumentError, "user_attribute_pe must be in policy machine with uuid #{policy_machine_uuid}")
       end
 
-      # argument errors for operation_set
-      raise(ArgumentError, "operation_set must be a Set of Operations") unless operation_set.is_a?(Set)
-      raise(ArgumentError, "operation_set must not be empty") if operation_set.empty?
-      operation_set.each do |op|
+      # argument errors for set_of_operation_objects
+      raise(ArgumentError, "set_of_operation_objects must be a Set of Operations") unless set_of_operation_objects.is_a?(Set)
+      raise(ArgumentError, "set_of_operation_objects must not be empty") if set_of_operation_objects.empty?
+      set_of_operation_objects.each do |op|
         unless op.is_a?(PM::Operation)
           raise(ArgumentError, "expected #{op} to be PM::Operation; got #{op.class}")
         end
@@ -64,7 +65,7 @@ module PM
 
       pm_storage_adapter.add_association(
         user_attribute_pe.stored_pe,
-        Set.new(operation_set.map(&:stored_pe)),
+        Set.new(set_of_operation_objects.map(&:stored_pe)),
         object_attribute_pe.stored_pe,
         policy_machine_uuid
       )

--- a/lib/policy_machine/association.rb
+++ b/lib/policy_machine/association.rb
@@ -2,10 +2,10 @@ module PM
   class Association
     attr_accessor :user_attribute
     attr_accessor :set_of_operation_objects
-    # attr_accessor :operation_set
+    attr_accessor :operation_set
     attr_accessor :object_attribute
 
-    def initialize(stored_user_attribute, stored_set_of_operation_objects, stored_object_attribute, pm_storage_adapter)
+    def initialize(stored_user_attribute, stored_set_of_operation_objects, stored_operation_set, stored_object_attribute, pm_storage_adapter)
       @user_attribute = PM::PolicyElement.convert_stored_pe_to_pe(
         stored_user_attribute,
         pm_storage_adapter,
@@ -21,6 +21,12 @@ module PM
         )
         @set_of_operation_objects << op
       end
+
+      @operation_set = PM::PolicyElement.convert_stored_pe_to_pe(
+        stored_operation_set,
+        pm_storage_adapter,
+        PM::OperationSet
+      )
 
       @object_attribute = PM::PolicyElement.convert_stored_pe_to_pe(
         stored_object_attribute,
@@ -38,7 +44,7 @@ module PM
 
     # Create an association given persisted policy elements
     #
-    def self.create(user_attribute_pe, set_of_operation_objects, object_attribute_pe, policy_machine_uuid, pm_storage_adapter)
+    def self.create(user_attribute_pe, set_of_operation_objects, operation_set, object_attribute_pe, policy_machine_uuid, pm_storage_adapter)
       # argument errors for user_attribute_pe
       raise(ArgumentError, "user_attribute_pe must be a UserAttribute.") unless user_attribute_pe.is_a?(PM::UserAttribute)
       unless user_attribute_pe.policy_machine_uuid == policy_machine_uuid
@@ -57,6 +63,12 @@ module PM
         end
       end
 
+      #argument errors for operation_set
+      raise(ArgumentError, "operation_set must be an OperationSet") unless operation_set.is_a?(PM::OperationSet)
+      unless operation_set.policy_machine_uuid == policy_machine_uuid
+        raise(ArgumentError, "operation_set must be in policy machine with uuid #{policy_machine_uuid}")
+      end
+
       # argument errors for object_attribute_pe
       raise(ArgumentError, "object_attribute_pe must be an ObjectAttribute.") unless object_attribute_pe.is_a?(PM::ObjectAttribute)
       unless object_attribute_pe.policy_machine_uuid == policy_machine_uuid
@@ -66,6 +78,7 @@ module PM
       pm_storage_adapter.add_association(
         user_attribute_pe.stored_pe,
         Set.new(set_of_operation_objects.map(&:stored_pe)),
+        operation_set,
         object_attribute_pe.stored_pe,
         policy_machine_uuid
       )

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -235,13 +235,20 @@ module PM
     # Associations are arrays of PM::Attributes.
     def associations
       pm_storage_adapter.associations_with(self.stored_pe).map do |assoc|
-        PM::Association.new(assoc[0], assoc[1], assoc[2], pm_storage_adapter)
+        PM::Association.new(assoc[0], assoc[1], assoc[2], assoc[3], pm_storage_adapter)
       end
     end
 
     protected
     def allowed_assignee_classes
       []
+    end
+  end
+
+  class OperationSet < PolicyElement
+
+    def allowed_assignee_classes
+      [OperationSet, Operation]
     end
   end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -284,7 +284,7 @@ module PolicyMachineStorageAdapter
                                             .where(operation_id: removed_operation_objects.map(&:id))
                                             .delete_all
           OperationsPolicyElementAssociation.import([:policy_element_association_id, :operation_id],
-                                                     new_operation_objects.map{ |op| [self.id, op.id] },
+                                                     new_operation_objects.map { |op| [self.id, op.id] },
                                                      validate: false)
         end
         self.clear_association_cache

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -218,8 +218,8 @@ module PolicyMachineStorageAdapter
       end
 
       def self.bulk_associate(associations, upsert_buffer)
-        associations.map! do |user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid|
-          [PolicyElementAssociation.new(user_attribute_id: user_attribute.id, object_attribute_id: object_attribute.id),
+        associations.map! do |user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid|
+          [PolicyElementAssociation.new(user_attribute_id: user_attribute.id, object_attribute_id: object_attribute.id, operation_set_id: operation_set.id),
            set_of_operation_objects]
         end
         PolicyElementAssociation.import(associations.map(&:first), on_duplicate_key_ignore: true)
@@ -256,6 +256,10 @@ module PolicyMachineStorageAdapter
       has_and_belongs_to_many :policy_element_associations, class_name: 'PolicyMachineStorageAdapter::ActiveRecord::PolicyElementAssociation', join_table: 'operations_policy_element_associations'
     end
 
+    class OperationSet < PolicyElement
+      has_many :policy_element_associations, dependent: :destroy
+    end
+
     class PolicyClass < PolicyElement
     end
 
@@ -265,6 +269,7 @@ module PolicyMachineStorageAdapter
 
       belongs_to :user_attribute
       belongs_to :object_attribute
+      belongs_to :operation_set
 
       #TODO: ActiveRecord's generated operations= method is inefficient, makes 1 query for each op added or removed even though there's no hooks
       # Awkward manual implementation for now, but in the future change this to an hstore or something in the postgres adapter,
@@ -285,10 +290,11 @@ module PolicyMachineStorageAdapter
         self.clear_association_cache
       end
 
-      def self.add_association(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
+      def self.add_association(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
         where(
-          user_attribute_id: user_attribute.id,
-          object_attribute_id: object_attribute.id
+          user_attribute: user_attribute.id,
+          object_attribute_id: object_attribute.id,
+          operation_set_id: operation_set.id
         ).first_or_create.operations = set_of_operation_objects.to_a
       end
 
@@ -297,7 +303,7 @@ module PolicyMachineStorageAdapter
     class OperationsPolicyElementAssociation < ::ActiveRecord::Base
     end
 
-    POLICY_ELEMENT_TYPES = %w(user user_attribute object object_attribute operation policy_class)
+    POLICY_ELEMENT_TYPES = %w(user user_attribute object object_attribute operation operation_set policy_class)
 
     POLICY_ELEMENT_TYPES.each do |pe_type|
       ##
@@ -559,17 +565,17 @@ module PolicyMachineStorageAdapter
     # and object_attribute already exists, then replace it with that given in the arguments.
     # Returns true if the association was added and false otherwise.
     #
-    def add_association(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
+    def add_association(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
       if self.buffering?
-        associate_later(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
+        associate_later(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
       else
-        PolicyElementAssociation.add_association(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
+        PolicyElementAssociation.add_association(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
       end
     end
 
     #TODO PM uuid potentially useful for future optimization, currently unused
-    def associate_later(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
-      buffers[:associations] << [user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid]
+    def associate_later(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
+      buffers[:associations] << [user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid]
     end
 
     ##
@@ -581,10 +587,10 @@ module PolicyMachineStorageAdapter
     # If no associations are found then the empty array should be returned.
     #
     def associations_with(operation)
-      assocs = operation.policy_element_associations(true).includes(:user_attribute, :operations, :object_attribute).all
+      assocs = operation.policy_element_associations(true).includes(:user_attribute, :operations, :operation_set, :object_attribute).all
       assocs.map do |assoc|
         assoc.clear_association_cache #TODO Either do this better (touch through HABTM on bulk insert?) or dont do this?
-        [assoc.user_attribute, Set.new(assoc.operations), assoc.object_attribute]
+        [assoc.user_attribute, Set.new(assoc.operations), assoc.operation_set, assoc.object_attribute]
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -219,7 +219,9 @@ module PolicyMachineStorageAdapter
 
       def self.bulk_associate(associations, upsert_buffer)
         associations.map! do |user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid|
-          [PolicyElementAssociation.new(user_attribute_id: user_attribute.id, object_attribute_id: object_attribute.id, operation_set_id: operation_set.id),
+          [PolicyElementAssociation.new(user_attribute_id: user_attribute.id,
+                                        object_attribute_id: object_attribute.id,
+                                        operation_set_id: operation_set.id),
            set_of_operation_objects]
         end
         PolicyElementAssociation.import(associations.map(&:first), on_duplicate_key_ignore: true)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -294,7 +294,7 @@ module PolicyMachineStorageAdapter
 
       def self.add_association(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
         where(
-          user_attribute: user_attribute.id,
+          user_attribute_id: user_attribute.id,
           object_attribute_id: object_attribute.id,
           operation_set_id: operation_set.id
         ).first_or_create.operations = set_of_operation_objects.to_a

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -195,7 +195,7 @@ module PolicyMachineStorageAdapter
         assoc[1].include?(operation)
       end
 
-      matching.map{ |m| [m[0], m[1], m[2], m[3]] }
+      matching.map { |m| [m[0], m[1], m[2], m[3]] }
     end
 
     ##

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -179,10 +179,10 @@ module PolicyMachineStorageAdapter
     ##
     # Add the given association to the policy map.  If an association between user_attribute
     # and object_attribute already exists, then replace it with that given in the arguments.
-    def add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
+    def add_association(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
       # TODO:  scope by policy machine uuid
       associations[user_attribute.unique_identifier + object_attribute.unique_identifier] =
-        [user_attribute, operation_set, object_attribute]
+        [user_attribute, set_of_operation_objects, object_attribute]
 
       true
     end
@@ -190,7 +190,7 @@ module PolicyMachineStorageAdapter
     ##
     # Return all associations in which the given operation is included
     # Returns an array of arrays.  Each sub-array is of the form
-    # [user_attribute, operation_set, object_attribute]
+    # [user_attribute, set_of_operation_objects, object_attribute]
     def associations_with(operation)
       matching = associations.values.select do |assoc|
         assoc[1].include?(operation)

--- a/lib/policy_machine_storage_adapters/in_memory.rb
+++ b/lib/policy_machine_storage_adapters/in_memory.rb
@@ -6,7 +6,7 @@ require 'policy_machine'
 module PolicyMachineStorageAdapter
   class InMemory
 
-    POLICY_ELEMENT_TYPES = %w(user user_attribute object object_attribute operation policy_class)
+    POLICY_ELEMENT_TYPES = %w(user user_attribute object object_attribute operation operation_set policy_class)
 
     def buffering?
       false
@@ -163,7 +163,6 @@ module PolicyMachineStorageAdapter
       policy_elements.delete(element)
     end
 
-    ##
     # Update a persisted policy element
     #
     def update(element, changes_hash)
@@ -179,10 +178,10 @@ module PolicyMachineStorageAdapter
     ##
     # Add the given association to the policy map.  If an association between user_attribute
     # and object_attribute already exists, then replace it with that given in the arguments.
-    def add_association(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
+    def add_association(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
       # TODO:  scope by policy machine uuid
-      associations[user_attribute.unique_identifier + object_attribute.unique_identifier] =
-        [user_attribute, set_of_operation_objects, object_attribute]
+     associations[user_attribute.unique_identifier + object_attribute.unique_identifier] =
+        [user_attribute, set_of_operation_objects, operation_set, object_attribute]
 
       true
     end
@@ -196,7 +195,7 @@ module PolicyMachineStorageAdapter
         assoc[1].include?(operation)
       end
 
-      matching.map{ |m| [m[0], m[1], m[2]] }
+      matching.map{ |m| [m[0], m[1], m[2], m[3]] }
     end
 
     ##

--- a/lib/policy_machine_storage_adapters/neography.rb
+++ b/lib/policy_machine_storage_adapters/neography.rb
@@ -163,7 +163,7 @@ module PolicyMachineStorageAdapter
     ##
     # Add the given association to the policy map.  If an association between user_attribute
     # and object_attribute already exists, then replace it with that given in the arguments.
-    def add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
+    def add_association(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
       remove_association(user_attribute, object_attribute, policy_machine_uuid)
 
       # TODO:  scope by policy machine uuid
@@ -173,12 +173,12 @@ module PolicyMachineStorageAdapter
         :policy_machine_uuid => policy_machine_uuid,
         :user_attribute_unique_identifier => user_attribute.unique_identifier,
         :object_attribute_unique_identifier => object_attribute.unique_identifier,
-        :operations => operation_set.map(&:unique_identifier).to_json,
+        :operations => set_of_operation_objects.map(&:unique_identifier).to_json,
       }
       persisted_assoc = ::Neography::Node.create(node_attrs)
       persisted_assoc.add_to_index('associations', 'unique_identifier', unique_identifier)
 
-      [user_attribute, object_attribute, *operation_set].each do |element|
+      [user_attribute, object_attribute, *set_of_operation_objects].each do |element|
         ::Neography::Relationship.create(:in_association, element, persisted_assoc)
       end
 
@@ -188,20 +188,20 @@ module PolicyMachineStorageAdapter
     ##
     # Return all associations in which the given operation is included
     # Returns an array of arrays.  Each sub-array is of the form
-    # [user_attribute, operation_set, object_attribute]
+    # [user_attribute, set_of_operation_objects, object_attribute]
     #
     def associations_with(operation)
       operation.outgoing(:in_association).map do |association|
         user_attribute = ::Neography::Node.find('nodes', 'unique_identifier', association.user_attribute_unique_identifier)
         object_attribute = ::Neography::Node.find('nodes', 'unique_identifier', association.object_attribute_unique_identifier)
 
-        operation_set = Set.new
+        set_of_operation_objects = Set.new
         JSON.parse(association.operations).each do |op_unique_id|
           op_node = ::Neography::Node.find('nodes', 'unique_identifier', op_unique_id)
-          operation_set << op_node
+          set_of_operation_objects << op_node
         end
 
-        [user_attribute, operation_set, object_attribute]
+        [user_attribute, set_of_operation_objects, object_attribute]
       end
     end
 

--- a/lib/policy_machine_storage_adapters/template.rb
+++ b/lib/policy_machine_storage_adapters/template.rb
@@ -159,7 +159,7 @@ module PolicyMachineStorageAdapter
     # and object_attribute already exists, then replace it with that given in the arguments.
     # Returns true if the association was added and false otherwise.
     #
-    def add_association(user_attribute, operation_set, object_attribute, policy_machine_uuid)
+    def add_association(user_attribute, set_of_operation_objects, object_attribute, policy_machine_uuid)
 
     end
 

--- a/lib/policy_machine_storage_adapters/template.rb
+++ b/lib/policy_machine_storage_adapters/template.rb
@@ -36,6 +36,8 @@ module PolicyMachineStorageAdapter
     def add_operation(unique_identifier, policy_machine_uuid, extra_attributes = {})
 
     end
+    def add_operation_set(unique_identifier, policy_machine_uuid, extra_attributes = {})
+    end
     def add_policy_class(unique_identifier, policy_machine_uuid, extra_attributes = {})
 
     end
@@ -59,6 +61,9 @@ module PolicyMachineStorageAdapter
 
     end
     def find_all_of_type_operation(options = {})
+
+    end
+    def find_all_of_type_operation_set(options = {})
 
     end
     def find_all_of_type_policy_class(options = {})

--- a/spec/policy_machine/association_spec.rb
+++ b/spec/policy_machine/association_spec.rb
@@ -17,7 +17,6 @@ describe PM::Association do
       @other_op = other_pm.create_operation('delete')
     end
 
-    #TODO: check arity crap
     it 'raises when first argument is not a user attribute' do
       expect{ PM::Association.create(@object_attribute, @set_of_operation_objects, @operation_set, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "user_attribute_pe must be a UserAttribute.")

--- a/spec/policy_machine/association_spec.rb
+++ b/spec/policy_machine/association_spec.rb
@@ -9,6 +9,7 @@ describe PM::Association do
       @operation1 = @policy_machine.create_operation('read')
       @operation2 = @policy_machine.create_operation('write')
       @set_of_operation_objects = Set.new [@operation1, @operation2]
+      @operation_set = @policy_machine.create_operation_set('reader_writer')
       @user_attribute = @policy_machine.create_user_attribute('UA name')
 
       other_pm = PolicyMachine.new
@@ -16,43 +17,44 @@ describe PM::Association do
       @other_op = other_pm.create_operation('delete')
     end
 
+    #TODO: check arity crap
     it 'raises when first argument is not a user attribute' do
-      expect{ PM::Association.create(@object_attribute, @set_of_operation_objects, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@object_attribute, @set_of_operation_objects, @operation_set, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "user_attribute_pe must be a UserAttribute.")
     end
 
     it 'raises when first argument is not in given policy machine' do
-      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, @object_attribute, "blah", @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute, "blah", @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "user_attribute_pe must be in policy machine with uuid blah")
     end
 
     it 'raises when second argument is not a set' do
-      expect{ PM::Association.create(@user_attribute, 1, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, 1, @operation_set, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "set_of_operation_objects must be a Set of Operations")
     end
 
     it 'raises when second argument is empty set' do
-      expect{ PM::Association.create(@user_attribute, Set.new, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, Set.new, @operation_set, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "set_of_operation_objects must not be empty")
     end
 
     it 'raises when second argument is a set in which at least one element is not a PM::Operation' do
-      expect{ PM::Association.create(@user_attribute, Set.new([@operation1, 1]), @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, Set.new([@operation1, 1]), @operation_set, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "expected 1 to be PM::Operation; got Fixnum")
     end
 
     it 'raises when second argument is a set in which at least one element is a PM::Operation which is in a different policy machine' do
-      expect{ PM::Association.create(@user_attribute, Set.new([@other_op]), @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, Set.new([@other_op]), @operation_set, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "expected #{@other_op.unique_identifier} to be in Policy Machine with uuid #{@policy_machine.uuid}; got #{@other_op.policy_machine_uuid}")
     end
 
     it 'raises when third argument is not an object attribute' do
-      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, "abc", @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, @operation_set, "abc", @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "object_attribute_pe must be an ObjectAttribute.")
     end
 
     it 'raises when third argument is not in given policy machine' do
-      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, @other_oa, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, @operation_set, @other_oa, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "object_attribute_pe must be in policy machine with uuid #{@policy_machine.uuid}")
     end
 

--- a/spec/policy_machine/association_spec.rb
+++ b/spec/policy_machine/association_spec.rb
@@ -8,7 +8,7 @@ describe PM::Association do
       @object_attribute = @policy_machine.create_object_attribute('OA name')
       @operation1 = @policy_machine.create_operation('read')
       @operation2 = @policy_machine.create_operation('write')
-      @operation_set = Set.new [@operation1, @operation2]
+      @set_of_operation_objects = Set.new [@operation1, @operation2]
       @user_attribute = @policy_machine.create_user_attribute('UA name')
 
       other_pm = PolicyMachine.new
@@ -17,23 +17,23 @@ describe PM::Association do
     end
 
     it 'raises when first argument is not a user attribute' do
-      expect{ PM::Association.create(@object_attribute, @operation_set, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@object_attribute, @set_of_operation_objects, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "user_attribute_pe must be a UserAttribute.")
     end
 
     it 'raises when first argument is not in given policy machine' do
-      expect{ PM::Association.create(@user_attribute, @operation_set, @object_attribute, "blah", @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, @object_attribute, "blah", @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "user_attribute_pe must be in policy machine with uuid blah")
     end
 
     it 'raises when second argument is not a set' do
       expect{ PM::Association.create(@user_attribute, 1, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
-        to raise_error(ArgumentError, "operation_set must be a Set of Operations")
+        to raise_error(ArgumentError, "set_of_operation_objects must be a Set of Operations")
     end
 
     it 'raises when second argument is empty set' do
       expect{ PM::Association.create(@user_attribute, Set.new, @object_attribute, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
-        to raise_error(ArgumentError, "operation_set must not be empty")
+        to raise_error(ArgumentError, "set_of_operation_objects must not be empty")
     end
 
     it 'raises when second argument is a set in which at least one element is not a PM::Operation' do
@@ -47,12 +47,12 @@ describe PM::Association do
     end
 
     it 'raises when third argument is not an object attribute' do
-      expect{ PM::Association.create(@user_attribute, @operation_set, "abc", @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, "abc", @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "object_attribute_pe must be an ObjectAttribute.")
     end
 
     it 'raises when third argument is not in given policy machine' do
-      expect{ PM::Association.create(@user_attribute, @operation_set, @other_oa, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
+      expect{ PM::Association.create(@user_attribute, @set_of_operation_objects, @other_oa, @policy_machine.uuid, @policy_machine.policy_machine_storage_adapter) }.
         to raise_error(ArgumentError, "object_attribute_pe must be in policy machine with uuid #{@policy_machine.uuid}")
     end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -83,13 +83,14 @@ describe 'ActiveRecord' do
         let(:user) { pm.create_user('user') }
         let(:pm2_user) { pm2.create_user('PM 2 user') }
         let(:operation) { pm.create_operation('operation') }
+        let(:op_set) { pm.create_operation_set('op_set')}
         let(:user_attribute) { pm.create_user_attribute('user_attribute') }
         let(:object_attribute) { pm.create_object_attribute('object_attribute') }
         let(:object) { pm.create_object('object') }
 
         it 'deletes only those assignments that were on deleted elements' do
           pm.add_assignment(user, user_attribute)
-          pm.add_association(user_attribute, Set.new([operation]), object_attribute)
+          pm.add_association(user_attribute, Set.new([operation]), op_set, object_attribute)
           pm.add_assignment(object, object_attribute)
 
           expect(pm.is_privilege?(user, operation, object)).to be
@@ -233,7 +234,8 @@ describe 'ActiveRecord' do
               pm.bulk_persist do
                 operation = pm.create_operation('drink')
                 operations = [operation, PM::Prohibition.on(operation), PM::Prohibition.on(operation)]
-                pm.add_association(caffeinated, Set.new(operations), cup)
+                op_set = pm.create_operation_set('new_op_set')
+                pm.add_association(caffeinated, Set.new(operations), op_set, cup)
               end
 
               associated_operation_strings = pm.policy_machine_storage_adapter.associations_with(caffeinated.stored_pe).first.second.to_a.map(&:unique_identifier)
@@ -350,11 +352,12 @@ describe 'ActiveRecord' do
         @pm = PolicyMachine.new(:name => 'ActiveRecord PM', :storage_adapter => PolicyMachineStorageAdapter::ActiveRecord)
         @u1 = @pm.create_user('u1')
         @op = @pm.create_operation('own')
+        @op_set = @pm.create_operation_set('owner')
         @user_attributes = (1..n).map { |i| @pm.create_user_attribute("ua#{i}") }
         @object_attributes = (1..n).map { |i| @pm.create_object_attribute("oa#{i}") }
         @objects = (1..n).map { |i| @pm.create_object("o#{i}") }
         @user_attributes.each { |ua| @pm.add_assignment(@u1, ua) }
-        @object_attributes.product(@user_attributes) { |oa, ua| @pm.add_association(ua, Set.new([@op]), oa) }
+        @object_attributes.product(@user_attributes) { |oa, ua| @pm.add_association(ua, Set.new([@op]), @op_set, oa) }
         @object_attributes.zip(@objects) { |oa, o| @pm.add_assignment(o, oa) }
       end
 
@@ -377,6 +380,7 @@ describe 'ActiveRecord' do
       @pm2_u1 = @pm2.create_user('pm2 u1')
 
       @op = @pm.create_operation('own')
+      @op_set = @pm.create_operation_set('owner')
       @pm2_op = @pm2.create_operation('pm2 op')
 
       @user_attributes = (1..n).map { |i| @pm.create_user_attribute("ua#{i}") }
@@ -385,7 +389,7 @@ describe 'ActiveRecord' do
       @pm3_user_attribute = @pm3.create_user_attribute('pm3_user_attribute')
 
       @user_attributes.each { |ua| @pm.add_assignment(@u1, ua) }
-      @object_attributes.product(@user_attributes) { |oa, ua| @pm.add_association(ua, Set.new([@op]), oa) }
+      @object_attributes.product(@user_attributes) { |oa, ua| @pm.add_association(ua, Set.new([@op]), @op_set, oa) }
       @object_attributes.zip(@objects) { |oa, o| @pm.add_assignment(o, oa) }
       @pm.add_assignment(@user_attributes.first, @user_attributes.second)
 

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -860,7 +860,6 @@ shared_examples "a policy machine" do
             [@u3, @r, @o1], [@u3, @r, @o2], [@u3, @r, @o3], [@u4, @e, @o4]
           ]
 
-          binding.pry if policy_machine.privileges.any? { |p| p == nil }
           assert_pm_privilege_expectations(policy_machine.privileges, expected_privileges)
         end
 

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -347,9 +347,8 @@ shared_examples "a policy machine" do
           .to raise_error(ArgumentError, "#{ua.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
 
-      #TODO Add third
       it 'raises when third argument is not a PolicyElement' do
-        expect{ policy_machine.add_association(@user_attribute, @set_of_oepration_objects, @operation_set, 3) }
+        expect{ policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, 3) }
           .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got #{SmallNumber} instead")
       end
 
@@ -425,6 +424,10 @@ shared_examples "a policy machine" do
     it 'can negate operations expressed as PM::Operations' do
       expect(PM::Prohibition.on(policy_machine.create_operation('fly'))).to be_a PM::Operation
     end
+  end
+
+  describe 'OperationSets' do
+
   end
 
   describe 'User Attributes' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -426,10 +426,6 @@ shared_examples "a policy machine" do
     end
   end
 
-  describe 'OperationSets' do
-
-  end
-
   describe 'User Attributes' do
     describe '#extra_attributes' do
       it 'accepts and persists arbitrary extra attributes' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -328,41 +328,41 @@ shared_examples "a policy machine" do
         @object_attribute = policy_machine.create_object_attribute('OA name')
         @operation1 = policy_machine.create_operation('read')
         @operation2 = policy_machine.create_operation('write')
-        @operation_set = Set.new [@operation1, @operation2]
+        @set_of_operation_objects = Set.new [@operation1, @operation2]
         @user_attribute = policy_machine.create_user_attribute('UA name')
       end
 
       it 'raises when first argument is not a PolicyElement' do
-        expect{ policy_machine.add_association("234", @operation_set, @object_attribute) }
+        expect{ policy_machine.add_association("234", @set_of_operation_objects, @object_attribute) }
           .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got String instead")
       end
 
       it 'raises when first argument is not in policy machine' do
         pm2 = PolicyMachine.new
         ua = pm2.create_user_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_association(ua, @operation_set, @object_attribute) }
+        expect{ policy_machine.add_association(ua, @set_of_operation_objects, @object_attribute) }
           .to raise_error(ArgumentError, "#{ua.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
 
       it 'raises when third argument is not a PolicyElement' do
-        expect{ policy_machine.add_association(@user_attribute, @operation_set, 3) }
+        expect{ policy_machine.add_association(@user_attribute, @set_of_operation_objects, 3) }
           .to raise_error(ArgumentError, "arg must each be a kind of PolicyElement; got Fixnum instead")
       end
 
       it 'raises when third argument is not in policy machine' do
         pm2 = PolicyMachine.new
         oa = pm2.create_object_attribute(SecureRandom.uuid)
-        expect{ policy_machine.add_association(@user_attribute, @operation_set, oa) }
+        expect{ policy_machine.add_association(@user_attribute, @set_of_operation_objects, oa) }
           .to raise_error(ArgumentError, "#{oa.unique_identifier} is not in policy machine with uuid #{policy_machine.uuid}")
       end
 
       it 'allows an association to be made between an existing user_attribute, operation set and object attribute (returns true)' do
-        policy_machine.add_association(@user_attribute, @operation_set, @object_attribute).should be_true
+        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @object_attribute).should be_true
       end
 
       it 'handles non-unique operation sets' do
-        @operation_set << @operation1.dup
-        policy_machine.add_association(@user_attribute, @operation_set, @object_attribute).should be_true
+        @set_of_operation_objects << @operation1.dup
+        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @object_attribute).should be_true
       end
 
       it 'overwrites old associations between the same attributes' do

--- a/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
+++ b/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
@@ -246,33 +246,36 @@ shared_examples "a policy machine storage adapter" do
   describe '#add_association' do
     before do
       @ua = policy_machine_storage_adapter.add_user_attribute('some_ua', 'some_policy_machine_uuid1')
+      @reader_writer = policy_machine_storage_adapter.add_operation_set('reader_writer', 'some_policy_machine_uuid1')
+      @reader = policy_machine_storage_adapter.add_operation_set('reader', 'some_policy_machine_uuid1')
       @r = policy_machine_storage_adapter.add_operation('read', 'some_policy_machine_uuid1')
       @w = policy_machine_storage_adapter.add_operation('write', 'some_policy_machine_uuid1')
       @oa = policy_machine_storage_adapter.add_object_attribute('some_oa', 'some_policy_machine_uuid1')
     end
 
     it 'returns true' do
-      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @oa, 'some_policy_machine_uuid1').should be_true
+      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1').should be_true
     end
 
     it 'stores the association' do
-      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @oa, 'some_policy_machine_uuid1')
+      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1')
       assocs_with_r = policy_machine_storage_adapter.associations_with(@r)
       assocs_with_r.size.should eq 1
       assocs_with_r[0][0].should == @ua
       assocs_with_r[0][1].to_a.should match_array([@r, @w])
-      assocs_with_r[0][2].should == @oa
+      assocs_with_r[0][3].should == @oa
 
       assocs_with_w = policy_machine_storage_adapter.associations_with(@w)
       assocs_with_w.size == 1
       assocs_with_w[0][0].should == @ua
       assocs_with_w[0][1].to_a.should match_array([@r, @w])
-      assocs_with_w[0][2].should == @oa
+      assocs_with_r[0][2].should == @reader_writer
+      assocs_with_r[0][3].should == @oa
     end
 
-    it 'overwrites a previously stored association' do
-      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @oa, 'some_policy_machine_uuid1')
-      policy_machine_storage_adapter.add_association(@ua, Set.new([@r]), @oa, 'some_policy_machine_uuid1')
+    xit 'overwrites a previously stored association' do
+      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1')
+      policy_machine_storage_adapter.add_association(@ua, Set.new([@r]), @reader, @oa, 'some_policy_machine_uuid1')
       assocs_with_r = policy_machine_storage_adapter.associations_with(@r)
       assocs_with_r.size == 1
       assocs_with_r[0][0].should == @ua
@@ -288,6 +291,8 @@ shared_examples "a policy machine storage adapter" do
       @ua = policy_machine_storage_adapter.add_user_attribute('some_ua', 'some_policy_machine_uuid1')
       @ua2 = policy_machine_storage_adapter.add_user_attribute('some_other_ua', 'some_policy_machine_uuid1')
       @r = policy_machine_storage_adapter.add_operation('read', 'some_policy_machine_uuid1')
+      @writer = policy_machine_storage_adapter.add_operation_set('writer', 'some_policy_machine_uuid1')
+      @writer_editor = policy_machine_storage_adapter.add_operation_set('writer_editor', 'some_policy_machine_uuid1')
       @w = policy_machine_storage_adapter.add_operation('write', 'some_policy_machine_uuid1')
       @e = policy_machine_storage_adapter.add_operation('execute', 'some_policy_machine_uuid1')
       @oa = policy_machine_storage_adapter.add_object_attribute('some_oa', 'some_policy_machine_uuid1')
@@ -298,17 +303,19 @@ shared_examples "a policy machine storage adapter" do
     end
 
     it 'returns structured array when given operation has associated associations' do
-      policy_machine_storage_adapter.add_association(@ua, Set.new([@w]), @oa, 'some_policy_machine_uuid1')
-      policy_machine_storage_adapter.add_association(@ua2, Set.new([@w, @e]), @oa, 'some_policy_machine_uuid1')
+      policy_machine_storage_adapter.add_association(@ua, Set.new([@w]), @writer, @oa, 'some_policy_machine_uuid1')
+      policy_machine_storage_adapter.add_association(@ua2, Set.new([@w, @e]), @writer_editor, @oa, 'some_policy_machine_uuid1')
       assocs_with_w = policy_machine_storage_adapter.associations_with(@w)
 
       assocs_with_w.size == 2
       assocs_with_w[0][0].should == @ua
       assocs_with_w[0][1].to_a.should == [@w]
-      assocs_with_w[0][2].should == @oa
+      assocs_with_w[0][2].should == @writer
+      assocs_with_w[0][3].should == @oa
       assocs_with_w[1][0].should == @ua2
       assocs_with_w[1][1].to_a.should match_array([@w, @e])
-      assocs_with_w[1][2].should == @oa
+      assocs_with_w[1][2].should == @writer_editor
+      assocs_with_w[1][3].should == @oa
 
     end
 

--- a/test/tasks/setup.rake
+++ b/test/tasks/setup.rake
@@ -13,6 +13,7 @@ namespace :pm do
 
         `bundle exec rails generate the_policy_machine:add_initial_policy_machine_tables -f`
         `bundle exec rails generate the_policy_machine:add_logical_links_table -f`
+        `bundle exec rails generate the_policy_machine:update_policy_element_associations_table -f`
         FileUtils.cp('../add_test_columns_migration.rb', './db/migrate/99999999999999_add_test_columns.rb')
 
         `bundle exec rake db:drop:all db:create db:migrate db:test:prepare`


### PR DESCRIPTION
Adds an operation set object to an association as the first part of a migration towards single operation sets being associated with a policy element association, eliminating the need for updates to the operation policy element association table