### PR TITLE
[MCC-276230] Fix/new import code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.5.1
-* Fix a bug in some of the new import code that prevented operation policy element
+* Fix a bug in some of the new import code that prevented operation policy
   element associations from saving correctly when encountering duplicates, also
   apply a new partial unique backing index to the policy element associations table
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.1
+* Fix a bug in some of the new import code that prevented operation policy element
+  element associations from saving correctly when encountering duplicates, also
+  apply a new partial unique backing index to the policy element associations table
+
 ## 1.5.0
 * Add an OperationSet element, and make an operation set a new required field for
   creating an Association.  This will be a required field to populate before consuming

--- a/lib/migrations/update_policy_element_associations_table.rb
+++ b/lib/migrations/update_policy_element_associations_table.rb
@@ -1,5 +1,10 @@
 class UpdatePolicyElementAssociationsTable < ActiveRecord::Migration
   def change
     add_column :policy_element_associations, :operation_set_id, :integer
+    add_index :policy_element_associations,
+              [:user_attribute_id, :object_attribute_id, :operation_set_id],
+              unique: true,
+              where: 'operation_set_id IS NOT NULL',
+              name: 'index_policy_element_associations_on_unique_triple' # generated name is too long
   end
 end

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 module PolicyMachine
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -224,17 +224,19 @@ module PolicyMachineStorageAdapter
                                         operation_set_id: operation_set.id),
            set_of_operation_objects]
         end
-        PolicyElementAssociation.import(associations.map(&:first), on_duplicate_key_ignore: true)
+
+        PolicyElementAssociation.import(associations.map(&:first),
+                                        on_duplicate_key_update: PolicyElementAssociation::DUPLICATE_KEY_UPDATE_PARAMS)
 
         #TODO: This should be a bulk upsert too but, among other things, AR doesn't understand nested arrays so deleting where a tuple
         # isn't in a list of tuples seems to require raw SQL
         # NB: operations= is a persistence method
-        associations.each do |model, set_of_operation_objects|
+        associations.each do |assoc, set_of_operation_objects|
           set_of_operation_objects.map! do |operation|
             operation.id ? operation : upsert_buffer[operation.unique_identifier]
           end
 
-          model.operations = set_of_operation_objects
+          assoc.operations = set_of_operation_objects
         end
       end
 
@@ -266,6 +268,13 @@ module PolicyMachineStorageAdapter
     end
 
     class PolicyElementAssociation < ::ActiveRecord::Base
+      # The index predicate is effectively the 'where' clause of the partial index on policy element associations
+      DUPLICATE_KEY_UPDATE_PARAMS = { conflict_target: [:user_attribute_id, :object_attribute_id, :operation_set_id],
+                                      index_predicate: 'operation_set_id IS NOT NULL',
+                                      columns: [:user_attribute_id, :object_attribute_id, :operation_set_id]
+                                    }
+
+
       # requires a join table (should be indexed!)
       has_and_belongs_to_many :operations, class_name: "PolicyMachineStorageAdapter::ActiveRecord::Operation", join_table: 'operations_policy_element_associations'
 
@@ -293,13 +302,13 @@ module PolicyMachineStorageAdapter
       end
 
       def self.add_association(user_attribute, set_of_operation_objects, operation_set, object_attribute, policy_machine_uuid)
-        where(
-          user_attribute_id: user_attribute.id,
-          object_attribute_id: object_attribute.id,
-          operation_set_id: operation_set.id
-        ).first_or_create.operations = set_of_operation_objects.to_a
-      end
+        pea_args = {user_attribute_id: user_attribute.id, object_attribute_id: object_attribute.id, operation_set_id: operation_set.id}
+        association = new(pea_args)
 
+        import([association], on_duplicate_key_ignore: DUPLICATE_KEY_UPDATE_PARAMS)
+
+        association.operations = set_of_operation_objects.to_a
+      end
     end
 
     class OperationsPolicyElementAssociation < ::ActiveRecord::Base

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -231,12 +231,12 @@ module PolicyMachineStorageAdapter
         #TODO: This should be a bulk upsert too but, among other things, AR doesn't understand nested arrays so deleting where a tuple
         # isn't in a list of tuples seems to require raw SQL
         # NB: operations= is a persistence method
-        associations.each do |assoc, set_of_operation_objects|
+        associations.each do |association, set_of_operation_objects|
           set_of_operation_objects.map! do |operation|
             operation.id ? operation : upsert_buffer[operation.unique_identifier]
           end
 
-          assoc.operations = set_of_operation_objects
+          association.operations = set_of_operation_objects
         end
       end
 
@@ -305,7 +305,7 @@ module PolicyMachineStorageAdapter
         pea_args = {user_attribute_id: user_attribute.id, object_attribute_id: object_attribute.id, operation_set_id: operation_set.id}
         association = new(pea_args)
 
-        import([association], on_duplicate_key_ignore: DUPLICATE_KEY_UPDATE_PARAMS)
+        import([association], on_duplicate_key_update: DUPLICATE_KEY_UPDATE_PARAMS)
 
         association.operations = set_of_operation_objects.to_a
       end


### PR DESCRIPTION
So #92 added some import code, but the problem with AR import on duplicate key ignore is that it doesn't update the id of the passed record, so subsequent `operations=` method would fail to create an operation policy element association record.  Also added the partial uniqueness constraint for the policy element association iff it has a operation_set_id here.