### PR TITLE
Upgrade to RSpec v3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.2
+* Upgrade RSpec dependency to version 3.5.0
+
 ## 1.5.1
 * Fix a bug in some of the new import code that prevented operation policy
   element associations from saving correctly when encountering duplicates, also

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -104,7 +104,7 @@ module PM
 
     # Delegates extra attribute reads to stored_pe
     def method_missing(meth, *args)
-      if args.none? && stored_pe.respond_to?(meth)
+      if stored_pe.respond_to?(meth)
         stored_pe.send(meth)
       else
         super

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "policy_machine"
-  s.version     = "1.4.1"
+  s.version     = "1.5.2"
   s.summary     = "Policy Machine!"
   s.description = "A ruby implementation of the Policy Machine authorization formalism."
   s.authors     = ['Matthew Szenher', 'Aaron Weiner']
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     s.add_dependency('pg')
     s.add_dependency('activerecord-hierarchical_query', '~> 0.0')
 
-  s.add_development_dependency('rspec', '~> 2.13.0')
+  s.add_development_dependency('rspec', '~> 3.5.0')
   s.add_development_dependency('simplecov', '~> 0.7.1')
   s.add_development_dependency('pry')
   s.add_development_dependency('pry-nav')

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -28,27 +28,27 @@ describe 'ActiveRecord' do
     describe 'find_all_of_type' do
 
       it 'warns once when filtering on an extra attribute' do
-        Warn.should_receive(:warn).once
+        expect(Warn).to receive(:warn).once
         2.times do
-          policy_machine_storage_adapter.find_all_of_type_user(foo: 'bar').should be_empty
+          expect(policy_machine_storage_adapter.find_all_of_type_user(foo: 'bar')).to be_empty
         end
       end
 
       context 'an extra attribute column has been added to the database' do
 
         it 'does not warn' do
-          Warn.should_not_receive(:warn)
-          policy_machine_storage_adapter.find_all_of_type_user(color: 'red').should be_empty
+          expect(Warn).to_not receive(:warn)
+          expect(policy_machine_storage_adapter.find_all_of_type_user(color: 'red')).to be_empty
         end
 
         it 'only returns elements that match the hash' do
           policy_machine_storage_adapter.add_object('some_uuid1', 'some_policy_machine_uuid1')
           policy_machine_storage_adapter.add_object('some_uuid2', 'some_policy_machine_uuid1', color: 'red')
           policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1', color: 'blue')
-          policy_machine_storage_adapter.find_all_of_type_object(color: 'red').should be_one
-          policy_machine_storage_adapter.find_all_of_type_object(color: nil).should be_one
-          policy_machine_storage_adapter.find_all_of_type_object(color: 'green').should be_none
-          policy_machine_storage_adapter.find_all_of_type_object(color: 'blue').map(&:color).should eql(['blue'])
+          expect(policy_machine_storage_adapter.find_all_of_type_object(color: 'red')).to be_one
+          expect(policy_machine_storage_adapter.find_all_of_type_object(color: nil)).to be_one
+          expect(policy_machine_storage_adapter.find_all_of_type_object(color: 'green')).to be_none
+          expect(policy_machine_storage_adapter.find_all_of_type_object(color: 'blue').map(&:color)).to eq(['blue'])
         end
 
         context 'pagination' do
@@ -58,21 +58,21 @@ describe 'ActiveRecord' do
 
           it 'paginates the results based on page and per_page' do
             results = policy_machine_storage_adapter.find_all_of_type_object(color: 'red', per_page: 2, page: 3)
-            results.first.unique_identifier.should == "uuid_4"
-            results.last.unique_identifier.should == "uuid_5"
+            expect(results.first.unique_identifier).to eq "uuid_4"
+            expect(results.last.unique_identifier).to eq "uuid_5"
           end
 
           # TODO: Investigate why this doesn't fail when not slicing params
           it 'does not paginate if no page or per_page' do
             results = policy_machine_storage_adapter.find_all_of_type_object(color: 'red').sort
-            results.first.unique_identifier.should == "uuid_0"
-            results.last.unique_identifier.should == "uuid_9"
+            expect(results.first.unique_identifier).to eq "uuid_0"
+            expect(results.last.unique_identifier).to eq "uuid_9"
           end
 
           it 'defaults to page 1 if no page' do
             results = policy_machine_storage_adapter.find_all_of_type_object(color: 'red', per_page: 3)
-            results.first.unique_identifier.should == "uuid_0"
-            results.last.unique_identifier.should == "uuid_2"
+            expect(results.first.unique_identifier).to eq "uuid_0"
+            expect(results.last.unique_identifier).to eq "uuid_2"
           end
         end
       end
@@ -341,7 +341,7 @@ describe 'ActiveRecord' do
 
       it 'retrieves the attribute value' do
         @o1.extra_attributes = {foo: 'bar'}
-        @o1.foo.should == 'bar'
+        expect(@o1.foo).to eq 'bar'
       end
 
     end
@@ -363,8 +363,8 @@ describe 'ActiveRecord' do
 
       it 'does not have O(n) database calls' do
         #TODO: Find a way to count all database calls that doesn't conflict with ActiveRecord magic
-        PolicyMachineStorageAdapter::ActiveRecord::Assignment.should_receive(:transitive_closure?).at_most(10).times
-        @pm.is_privilege?(@u1, @op, @objects.first).should be
+        expect(PolicyMachineStorageAdapter::ActiveRecord::Assignment).to receive(:transitive_closure?).at_most(10).times
+        expect(@pm.is_privilege?(@u1, @op, @objects.first)).to be true
       end
     end
   end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -181,9 +181,9 @@ describe 'ActiveRecord' do
               caffeinated.unassign(decaffeinated)
             end
 
-            expect(user.connected?(decaffeinated)).to be true
-            expect(user.connected?(caffeinated)).to be true
-            expect(caffeinated.connected?(decaffeinated)).to be false
+            expect(user.connected?(decaffeinated)).to be_truthy
+            expect(user.connected?(caffeinated)).to be_truthy
+            expect(caffeinated.connected?(decaffeinated)).to be_falsey
           end
 
           it 'deletes preexisting assignments removed' do
@@ -194,8 +194,8 @@ describe 'ActiveRecord' do
               caffeinated.unassign(decaffeinated)
             end
 
-            expect(user.connected?(caffeinated)).to be true
-            expect(caffeinated.connected?(decaffeinated)).to be false
+            expect(user.connected?(caffeinated)).to be_truthy
+            expect(caffeinated.connected?(decaffeinated)).to be_falsey
           end
 
           it 'creates an assignment if the assignment is created, deleted and then recreated' do
@@ -207,8 +207,8 @@ describe 'ActiveRecord' do
               user.assign_to(caffeinated)
             end
 
-            expect(user.connected?(caffeinated)).to be true
-            expect(user.connected?(decaffeinated)).to be false
+            expect(user.connected?(caffeinated)).to be_truthy
+            expect(user.connected?(decaffeinated)).to be_falsey
           end
 
           it 'creates an assigment if a preexisting assignment is deleted and then recreated' do
@@ -220,8 +220,8 @@ describe 'ActiveRecord' do
               user.assign_to(caffeinated)
             end
 
-            expect(user.connected?(caffeinated)).to be true
-            expect(user.connected?(decaffeinated)).to be false
+            expect(user.connected?(caffeinated)).to be_truthy
+            expect(user.connected?(decaffeinated)).to be_falsey
           end
 
         end
@@ -261,10 +261,10 @@ describe 'ActiveRecord' do
               mirror_user.unlink(decaffeinated)
             end
 
-            expect(user.linked?(is_evil)).to be true
-            expect(user.linked?(has_a_goatee)).to be false
-            expect(mirror_user.linked?(caffeinated)).to be true
-            expect(mirror_user.linked?(decaffeinated)).to be false
+            expect(user.linked?(is_evil)).to be_truthy
+            expect(user.linked?(has_a_goatee)).to be_falsey
+            expect(mirror_user.linked?(caffeinated)).to be_truthy
+            expect(mirror_user.linked?(decaffeinated)).to be_falsey
           end
 
           it 'deletes preexisting links removed' do
@@ -279,10 +279,10 @@ describe 'ActiveRecord' do
               mirror_user.unlink(decaffeinated)
             end
 
-            expect(user.linked?(is_evil)).to be true
-            expect(user.linked?(has_a_goatee)).to be false
-            expect(mirror_user.linked?(caffeinated)).to be true
-            expect(mirror_user.linked?(decaffeinated)).to be false
+            expect(user.linked?(is_evil)).to be_truthy
+            expect(user.linked?(has_a_goatee)).to be_falsey
+            expect(mirror_user.linked?(caffeinated)).to be_truthy
+            expect(mirror_user.linked?(decaffeinated)).to be_falsey
           end
 
           it 'creates a link if the link is created, deleted, and then recreated' do
@@ -299,10 +299,10 @@ describe 'ActiveRecord' do
               mirror_user.link_to(decaffeinated)
             end
 
-            expect(user.linked?(has_a_goatee)).to be true
-            expect(user.linked?(is_evil)).to be true
-            expect(mirror_user.linked?(caffeinated)).to be true
-            expect(mirror_user.linked?(decaffeinated)).to be true
+            expect(user.linked?(has_a_goatee)).to be_truthy
+            expect(user.linked?(is_evil)).to be_truthy
+            expect(mirror_user.linked?(caffeinated)).to be_truthy
+            expect(mirror_user.linked?(decaffeinated)).to be_truthy
           end
 
           it 'creates a link if a preexisting assignment is deleted and then recreated' do
@@ -320,10 +320,10 @@ describe 'ActiveRecord' do
               mirror_user.link_to(decaffeinated)
             end
 
-            expect(user.linked?(has_a_goatee)).to be true
-            expect(user.linked?(is_evil)).to be true
-            expect(mirror_user.linked?(caffeinated)).to be true
-            expect(mirror_user.linked?(decaffeinated)).to be true
+            expect(user.linked?(has_a_goatee)).to be_truthy
+            expect(user.linked?(is_evil)).to be_truthy
+            expect(mirror_user.linked?(caffeinated)).to be_truthy
+            expect(mirror_user.linked?(decaffeinated)).to be_truthy
           end
         end
       end
@@ -384,6 +384,8 @@ describe 'ActiveRecord' do
       @pm2_op = @pm2.create_operation('pm2 op')
 
       @user_attributes = (1..n).map { |i| @pm.create_user_attribute("ua#{i}") }
+      @user_attributes.first.update(color: 'red')
+
       @object_attributes = (1..n).map { |i| @pm.create_object_attribute("oa#{i}") }
       @objects = (1..n).map { |i| @pm.create_object("o#{i}") }
       @pm3_user_attribute = @pm3.create_user_attribute('pm3_user_attribute')

--- a/spec/policy_machine_storage_adapters/in_memory_spec.rb
+++ b/spec/policy_machine_storage_adapters/in_memory_spec.rb
@@ -15,21 +15,21 @@ describe PolicyMachineStorageAdapter::InMemory do
 
       it 'paginates the results based on page and per_page' do
         results = policy_machine_storage_adapter.find_all_of_type_object(color: 'red', per_page: 2, page: 3)
-        results.first.unique_identifier.should == "uuid_4"
-        results.last.unique_identifier.should == "uuid_5"
+        expect(results.first.unique_identifier).to eq "uuid_4"
+        expect(results.last.unique_identifier).to eq "uuid_5"
       end
 
       # TODO: Investigate why this doesn't fail when not slicing params
       it 'does not paginate if no page or per_page' do
         results = policy_machine_storage_adapter.find_all_of_type_object(color: 'red')
-        results.first.unique_identifier.should == "uuid_0"
-        results.last.unique_identifier.should == "uuid_9"
+        expect(results.first.unique_identifier).to eq "uuid_0"
+        expect(results.last.unique_identifier).to eq "uuid_9"
       end
 
       it 'defaults to page 1 if no page' do
         results = policy_machine_storage_adapter.find_all_of_type_object(color: 'red', per_page: 3)
-        results.first.unique_identifier.should == "uuid_0"
-        results.last.unique_identifier.should == "uuid_2"
+        expect(results.first.unique_identifier).to eq "uuid_0"
+        expect(results.last.unique_identifier).to eq "uuid_2"
       end
     end
   end

--- a/spec/policy_machine_storage_adapters/neography_spec.rb
+++ b/spec/policy_machine_storage_adapters/neography_spec.rb
@@ -31,7 +31,7 @@ describe 'Neography' do
         policy_machine_storage_adapter = PolicyMachineStorageAdapter::Neography.new
         src = policy_machine_storage_adapter.add_user('some_uuid1', 'some_policy_machine_uuid1')
         dst = policy_machine_storage_adapter.add_user_attribute('some_uuid2', 'some_policy_machine_uuid1')
-        policy_machine_storage_adapter.assign(src, dst).should be_falsey
+        expect(policy_machine_storage_adapter.assign(src, dst)).to be_falsey
       end
     end
   end

--- a/spec/policy_machine_storage_adapters/neography_spec.rb
+++ b/spec/policy_machine_storage_adapters/neography_spec.rb
@@ -31,7 +31,7 @@ describe 'Neography' do
         policy_machine_storage_adapter = PolicyMachineStorageAdapter::Neography.new
         src = policy_machine_storage_adapter.add_user('some_uuid1', 'some_policy_machine_uuid1')
         dst = policy_machine_storage_adapter.add_user_attribute('some_uuid2', 'some_policy_machine_uuid1')
-        policy_machine_storage_adapter.assign(src, dst).should be_false
+        policy_machine_storage_adapter.assign(src, dst).should be_falsey
       end
     end
   end

--- a/spec/support/policy_machine_helpers.rb
+++ b/spec/support/policy_machine_helpers.rb
@@ -15,9 +15,9 @@ def assert_pm_privilege_expectations(actual_privileges, expected_privileges)
 
     pp("expected to find #{[u_id, op_id, obj_id]}") if found_actual_priv.nil?
 
-    found_actual_priv.should_not be_nil
+    expect(found_actual_priv).to_not be_nil
   end
-  actual_privileges.count.should == expected_privileges.size
+  expect(actual_privileges.count).to eq(expected_privileges.size)
   assert_pm_scoped_privilege_expectations
 end
 
@@ -29,7 +29,7 @@ def assert_pm_scoped_privilege_expectations
     expected_scoped_privileges = policy_machine.operations.reject(&:prohibition?).grep(->op{policy_machine.is_privilege?(u, op.unique_identifier, o)}) do |op|
       [u, op, o]
     end
-    policy_machine.scoped_privileges(u,o).should =~ expected_scoped_privileges
+    expect(policy_machine.scoped_privileges(u,o)).to match_array(expected_scoped_privileges)
   end
 
 end

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -6,40 +6,39 @@ policy_element_types = ::PolicyMachine::POLICY_ELEMENT_TYPES
 shared_examples "a policy machine" do
   describe 'instantiation' do
     it 'has a default name' do
-      PolicyMachine.new.name.length.should_not == 0
+      expect(PolicyMachine.new.name.length).to_not eq 0
     end
 
     it 'can be named' do
       ['name', :name].each do |key|
-        PolicyMachine.new(key => 'my name').name.should == 'my name'
+        expect(PolicyMachine.new(key => 'my name').name).to eq 'my name'
       end
     end
 
     it 'sets the uuid if not specified' do
-      PolicyMachine.new.uuid.length.should_not == 0
+      expect(PolicyMachine.new.uuid.length).to_not eq 0
     end
 
     it 'allows uuid to be specified' do
       ['uuid', :uuid].each do |key|
-        PolicyMachine.new(key => 'my uuid').uuid.should == 'my uuid'
+        expect(PolicyMachine.new(key => 'my uuid').uuid).to eq 'my uuid'
       end
     end
 
     it 'raises when uuid is blank' do
       ['', '   '].each do |blank_value|
-        expect{ PolicyMachine.new(:uuid => blank_value) }
-          .to raise_error(ArgumentError, 'uuid cannot be blank')
+        expect{ PolicyMachine.new(:uuid => blank_value) }.to raise_error(ArgumentError, 'uuid cannot be blank')
       end
     end
 
     it 'defaults to in-memory storage adapter' do
-      PolicyMachine.new.policy_machine_storage_adapter.should be_a(::PolicyMachineStorageAdapter::InMemory)
+      expect(PolicyMachine.new.policy_machine_storage_adapter).to be_a(::PolicyMachineStorageAdapter::InMemory)
     end
 
     it 'allows user to set storage adapter' do
       ['storage_adapter', :storage_adapter].each do |key|
-        PolicyMachine.new(key => ::PolicyMachineStorageAdapter::Neography).policy_machine_storage_adapter.
-          should be_a(::PolicyMachineStorageAdapter::Neography)
+        storage_adapter = PolicyMachine.new(key => ::PolicyMachineStorageAdapter::Neography).policy_machine_storage_adapter
+        expect(storage_adapter).to be_a(::PolicyMachineStorageAdapter::Neography)
       end
     end
   end
@@ -65,7 +64,7 @@ shared_examples "a policy machine" do
           pe0 = policy_machine.send("create_#{allowed_assignment[0]}", SecureRandom.uuid)
           pe1 = policy_machine.send("create_#{allowed_assignment[1]}", SecureRandom.uuid)
 
-          policy_machine.add_assignment(pe0, pe1).should be_truthy
+          expect(policy_machine.add_assignment(pe0, pe1)).to be_truthy
         end
       end
 
@@ -116,11 +115,11 @@ shared_examples "a policy machine" do
 
       it 'removes an existing assignment (returns true)' do
         policy_machine.add_assignment(@pe0, @pe1)
-        policy_machine.remove_assignment(@pe0, @pe1).should be_truthy
+        expect(policy_machine.remove_assignment(@pe0, @pe1)).to be_truthy
       end
 
       it 'does not remove a non-existant assignment (returns false)' do
-        policy_machine.remove_assignment(@pe0, @pe1).should be_falsey
+        expect(policy_machine.remove_assignment(@pe0, @pe1)).to be_falsey
       end
 
       it 'raises when first argument is not a policy element' do
@@ -360,12 +359,12 @@ shared_examples "a policy machine" do
       end
 
       it 'allows an association to be made between an existing user_attribute, operation set and object attribute (returns true)' do
-        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute).should be_truthy
+        expect(policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute)).to be_truthy
       end
 
       it 'handles non-unique operation sets' do
         @set_of_operation_objects << @operation1.dup
-        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute).should be_truthy
+        expect(policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute)).to be_truthy
       end
 
       xit 'overwrites old associations between the same attributes' do
@@ -385,14 +384,14 @@ shared_examples "a policy machine" do
     PolicyMachine::POLICY_ELEMENT_TYPES.each do |pe_type|
       it "returns an array of all #{pe_type.to_s.pluralize}" do
         pe = policy_machine.send("create_#{pe_type}", 'some name')
-        policy_machine.send(pe_type.to_s.pluralize).should == [pe]
+        expect(policy_machine.send(pe_type.to_s.pluralize)).to eq([pe])
       end
 
       it "scopes by policy machine when finding an array of #{pe_type.to_s.pluralize}" do
         pe = policy_machine.send("create_#{pe_type}", 'some name')
         other_pm = PolicyMachine.new
         pe_in_other_machine = other_pm.send("create_#{pe_type}", 'some name')
-        policy_machine.send(pe_type.to_s.pluralize).should == [pe]
+        expect(policy_machine.send(pe_type.to_s.pluralize)).to eq([pe])
       end
     end
   end
@@ -430,8 +429,8 @@ shared_examples "a policy machine" do
     describe '#extra_attributes' do
       it 'accepts and persists arbitrary extra attributes' do
         @ua = policy_machine.create_user_attribute('ua1', foo: 'bar')
-        @ua.foo.should == 'bar'
-        policy_machine.user_attributes.last.foo.should == 'bar'
+        expect(@ua.foo).to eq 'bar'
+        expect(policy_machine.user_attributes.last.foo).to eq 'bar'
       end
     end
 
@@ -439,7 +438,7 @@ shared_examples "a policy machine" do
       it 'successfully deletes itself' do
         @ua = policy_machine.create_user_attribute('ua1')
         @ua.delete
-        policy_machine.user_attributes.should_not include(@ua)
+        expect(policy_machine.user_attributes).to_not include(@ua)
       end
     end
   end
@@ -448,39 +447,39 @@ shared_examples "a policy machine" do
     describe '#extra_attributes' do
       it 'accepts and persists arbitrary extra attributes' do
         @u = policy_machine.create_user('u1', foo: 'bar')
-        @u.foo.should == 'bar'
-        policy_machine.users.last.foo.should == 'bar'
+        expect(@u.foo).to eq 'bar'
+        expect(policy_machine.users.last.foo).to eq 'bar'
       end
 
       it 'updates persisted extra attributes' do
         @u = policy_machine.create_user('u1', foo: 'bar')
         @u.update(foo: 'baz')
-        @u.foo.should == 'baz'
-        policy_machine.users.last.foo.should == 'baz'
+        expect(@u.foo).to eq 'baz'
+        expect(policy_machine.users.last.foo).to eq 'baz'
       end
 
       it 'updates persisted extra attributes with new keys' do
         @u = policy_machine.create_user('u1', foo: 'bar')
         @u.update(foo: 'baz', bla: 'bar')
-        @u.foo.should == 'baz'
-        policy_machine.users.last.foo.should == 'baz'
+        expect(@u.foo).to eq 'baz'
+        expect(policy_machine.users.last.foo).to eq 'baz'
       end
 
       it 'does not remove old attributes when adding new ones' do
         @u = policy_machine.create_user('u1', foo: 'bar')
         @u.update(deleted: true)
-        @u.foo.should == 'bar'
-        policy_machine.users.last.foo.should == 'bar'
+        expect(@u.foo).to eq 'bar'
+        expect(policy_machine.users.last.foo).to eq 'bar'
       end
 
       it 'allows searching on any extra attribute keys' do
         policy_machine.create_user('u1', foo: 'bar')
         policy_machine.create_user('u2', foo: nil, attitude: 'sassy')
         silence_warnings do
-          policy_machine.users(foo: 'bar').should be_one
-          policy_machine.users(foo: nil).should be_one
-          policy_machine.users(foo: 'baz').should be_none
-          policy_machine.users(foo: 'bar', attitude: 'sassy').should be_none
+          expect(policy_machine.users(foo: 'bar')).to be_one
+          expect(policy_machine.users(foo: nil)).to be_one
+          expect(policy_machine.users(foo: 'baz')).to be_none
+          expect(policy_machine.users(foo: 'bar', attitude: 'sassy')).to be_none
         end
       end
     end
@@ -545,40 +544,40 @@ shared_examples "a policy machine" do
     end
 
     it 'returns true if privilege can be inferred from user, operation and object' do
-      policy_machine.is_privilege?(@u1, @w, @o1).should be_truthy
+      expect(policy_machine.is_privilege?(@u1, @w, @o1)).to be_truthy
     end
 
     it 'returns true if privilege can be inferred from user_attribute, operation and object' do
-      policy_machine.is_privilege?(@group1, @w, @o1).should be_truthy
+      expect(policy_machine.is_privilege?(@group1, @w, @o1)).to be_truthy
     end
 
     it 'returns true if privilege can be inferred from user, operation and object_attribute' do
-      policy_machine.is_privilege?(@u1, @w, @project1).should be_truthy
+      expect(policy_machine.is_privilege?(@u1, @w, @project1)).to be_truthy
     end
 
     it 'returns false if privilege cannot be inferred from arguments' do
-      policy_machine.is_privilege?(@u1, @w, @o2).should be_falsey
+      expect(policy_machine.is_privilege?(@u1, @w, @o2)).to be_falsey
     end
 
     it 'accepts the unique identifier for an operation in place of the operation' do
-      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o1).should be_truthy
+      expect(policy_machine.is_privilege?(@u1, @w.unique_identifier, @o1)).to be_truthy
     end
 
     it 'accepts the unique identifier in symbol form for an operation in place of the operation' do
-      policy_machine.is_privilege?(@u1, @w.unique_identifier.to_sym, @o1).should be_truthy
+      expect(policy_machine.is_privilege?(@u1, @w.unique_identifier.to_sym, @o1)).to be_truthy
     end
 
     it 'returns false on string input when the operation exists but the privilege does not' do
-      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o2).should be_falsey
+      expect(policy_machine.is_privilege?(@u1, @w.unique_identifier, @o2)).to be_falsey
     end
 
     it 'returns false on string input when the operation does not exist' do
-      policy_machine.is_privilege?(@u1, 'non-existent-operation', @o2).should be_falsey
+      expect(policy_machine.is_privilege?(@u1, 'non-existent-operation', @o2)).to be_falsey
     end
 
     it 'does not infer privileges from deleted attributes' do
       @group1.delete
-      policy_machine.is_privilege?(@u1, @w, @o1).should be_falsey
+      expect(policy_machine.is_privilege?(@u1, @w, @o1)).to be_falsey
     end
 
     describe 'options' do
@@ -602,26 +601,26 @@ shared_examples "a policy machine" do
           executer = policy_machine.create_operation_set('executer')
           e = policy_machine.create_operation('execute')
           policy_machine.add_association(@group1, Set.new([e]), executer, @project1)
-          policy_machine.is_privilege?(@u1, @w, @o2, :associations => e.associations).should be_falsey
+          expect(policy_machine.is_privilege?(@u1, @w, @o2, :associations => e.associations)).to be_falsey
         end
 
         it 'accepts associations in options[:associations]' do
-          policy_machine.is_privilege?(@u1, @w, @o1, :associations => @w.associations).should be_truthy
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, :associations => @w.associations)).to be_truthy
         end
 
         it "accepts associations in options['associations']" do
-          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations).should be_truthy
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations)).to be_truthy
         end
 
         it 'returns true when given association is part of the granting of a given privilege' do
-          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations).should be_truthy
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations)).to be_truthy
         end
 
         it 'returns false when given association is not part of the granting of a given privilege' do
           group2 = policy_machine.create_user_attribute('Group2')
 
           policy_machine.add_association(group2, Set.new([@w]), @writer, @project1)
-          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => [@w.associations.last]).should be_falsey
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => [@w.associations.last])).to be_falsey
         end
       end
 
@@ -632,16 +631,16 @@ shared_examples "a policy machine" do
         end
 
         it 'accepts in_user_attribute in options[:in_user_attribute]' do
-          policy_machine.is_privilege?(@u1, @w, @o1, :in_user_attribute => @group1).should be_truthy
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, :in_user_attribute => @group1)).to be_truthy
         end
 
         it "accepts in_user_attribute in options['in_user_attribute']" do
-          policy_machine.is_privilege?(@group1, @w, @o1, 'in_user_attribute' => @group1).should be_truthy
+          expect(policy_machine.is_privilege?(@group1, @w, @o1, 'in_user_attribute' => @group1)).to be_truthy
         end
 
         it 'returns false if given user is not in given in_user_attribute' do
           group2 = policy_machine.create_user_attribute('Group2')
-          policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => group2).should be_falsey
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => group2)).to be_falsey
         end
       end
 
@@ -652,16 +651,16 @@ shared_examples "a policy machine" do
         end
 
         it 'accepts in_object_attribute in options[:in_object_attribute]' do
-          policy_machine.is_privilege?(@u1, @w, @o1, :in_object_attribute => @project1).should be_truthy
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, :in_object_attribute => @project1)).to be_truthy
         end
 
         it "accepts in_object_attribute in options['in_object_attribute']" do
-          policy_machine.is_privilege?(@u1, @w, @project1, 'in_object_attribute' => @project1).should be_truthy
+          expect(policy_machine.is_privilege?(@u1, @w, @project1, 'in_object_attribute' => @project1)).to be_truthy
         end
 
         it 'returns false if given user is not in given in_object_attribute' do
           project2 = policy_machine.create_object_attribute('Project2')
-          policy_machine.is_privilege?(@u1, @w, @o1, 'in_object_attribute' => project2).should be_falsey
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, 'in_object_attribute' => project2)).to be_falsey
         end
 
         it 'accepts both in_user_attribute and in_object_attribute' do
@@ -689,11 +688,11 @@ shared_examples "a policy machine" do
     end
 
     it 'lists the user attributes for a user' do
-      policy_machine.list_user_attributes(@u2).should == [@group2]
+      expect(policy_machine.list_user_attributes(@u2)).to contain_exactly(@group2)
     end
 
     it 'searches multiple hops deep' do
-      policy_machine.list_user_attributes(@u1).should =~ [@group1, @subgroup1a]
+      expect(policy_machine.list_user_attributes(@u1)).to contain_exactly(@group1, @subgroup1a)
     end
 
     it 'raises an argument error when passed anything other than a user' do
@@ -707,7 +706,7 @@ shared_examples "a policy machine" do
       policy_machine.transaction do
         @oa = policy_machine.create_object_attribute('some_oa')
       end
-      policy_machine.object_attributes.should == [@oa]
+      expect(policy_machine.object_attributes).to contain_exactly(@oa)
     end
 
     it 'rolls back the block on error' do
@@ -719,7 +718,7 @@ shared_examples "a policy machine" do
           policy_machine.add_assignment(@oa2, :invalid_policy_class)
         end
       end.to raise_error(ArgumentError)
-      policy_machine.object_attributes.should == [@oa1]
+      expect(policy_machine.object_attributes).to contain_exactly(@oa1)
     end
   end
 

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -65,7 +65,7 @@ shared_examples "a policy machine" do
           pe0 = policy_machine.send("create_#{allowed_assignment[0]}", SecureRandom.uuid)
           pe1 = policy_machine.send("create_#{allowed_assignment[1]}", SecureRandom.uuid)
 
-          policy_machine.add_assignment(pe0, pe1).should be_true
+          policy_machine.add_assignment(pe0, pe1).should be_truthy
         end
       end
 
@@ -116,11 +116,11 @@ shared_examples "a policy machine" do
 
       it 'removes an existing assignment (returns true)' do
         policy_machine.add_assignment(@pe0, @pe1)
-        policy_machine.remove_assignment(@pe0, @pe1).should be_true
+        policy_machine.remove_assignment(@pe0, @pe1).should be_truthy
       end
 
       it 'does not remove a non-existant assignment (returns false)' do
-        policy_machine.remove_assignment(@pe0, @pe1).should be_false
+        policy_machine.remove_assignment(@pe0, @pe1).should be_falsey
       end
 
       it 'raises when first argument is not a policy element' do
@@ -360,12 +360,12 @@ shared_examples "a policy machine" do
       end
 
       it 'allows an association to be made between an existing user_attribute, operation set and object attribute (returns true)' do
-        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute).should be_true
+        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute).should be_truthy
       end
 
       it 'handles non-unique operation sets' do
         @set_of_operation_objects << @operation1.dup
-        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute).should be_true
+        policy_machine.add_association(@user_attribute, @set_of_operation_objects, @operation_set, @object_attribute).should be_truthy
       end
 
       xit 'overwrites old associations between the same attributes' do
@@ -545,40 +545,40 @@ shared_examples "a policy machine" do
     end
 
     it 'returns true if privilege can be inferred from user, operation and object' do
-      policy_machine.is_privilege?(@u1, @w, @o1).should be_true
+      policy_machine.is_privilege?(@u1, @w, @o1).should be_truthy
     end
 
     it 'returns true if privilege can be inferred from user_attribute, operation and object' do
-      policy_machine.is_privilege?(@group1, @w, @o1).should be_true
+      policy_machine.is_privilege?(@group1, @w, @o1).should be_truthy
     end
 
     it 'returns true if privilege can be inferred from user, operation and object_attribute' do
-      policy_machine.is_privilege?(@u1, @w, @project1).should be_true
+      policy_machine.is_privilege?(@u1, @w, @project1).should be_truthy
     end
 
     it 'returns false if privilege cannot be inferred from arguments' do
-      policy_machine.is_privilege?(@u1, @w, @o2).should be_false
+      policy_machine.is_privilege?(@u1, @w, @o2).should be_falsey
     end
 
     it 'accepts the unique identifier for an operation in place of the operation' do
-      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o1).should be_true
+      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o1).should be_truthy
     end
 
     it 'accepts the unique identifier in symbol form for an operation in place of the operation' do
-      policy_machine.is_privilege?(@u1, @w.unique_identifier.to_sym, @o1).should be_true
+      policy_machine.is_privilege?(@u1, @w.unique_identifier.to_sym, @o1).should be_truthy
     end
 
     it 'returns false on string input when the operation exists but the privilege does not' do
-      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o2).should be_false
+      policy_machine.is_privilege?(@u1, @w.unique_identifier, @o2).should be_falsey
     end
 
     it 'returns false on string input when the operation does not exist' do
-      policy_machine.is_privilege?(@u1, 'non-existent-operation', @o2).should be_false
+      policy_machine.is_privilege?(@u1, 'non-existent-operation', @o2).should be_falsey
     end
 
     it 'does not infer privileges from deleted attributes' do
       @group1.delete
-      policy_machine.is_privilege?(@u1, @w, @o1).should be_false
+      policy_machine.is_privilege?(@u1, @w, @o1).should be_falsey
     end
 
     describe 'options' do
@@ -602,26 +602,26 @@ shared_examples "a policy machine" do
           executer = policy_machine.create_operation_set('executer')
           e = policy_machine.create_operation('execute')
           policy_machine.add_association(@group1, Set.new([e]), executer, @project1)
-          policy_machine.is_privilege?(@u1, @w, @o2, :associations => e.associations).should be_false
+          policy_machine.is_privilege?(@u1, @w, @o2, :associations => e.associations).should be_falsey
         end
 
         it 'accepts associations in options[:associations]' do
-          policy_machine.is_privilege?(@u1, @w, @o1, :associations => @w.associations).should be_true
+          policy_machine.is_privilege?(@u1, @w, @o1, :associations => @w.associations).should be_truthy
         end
 
         it "accepts associations in options['associations']" do
-          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations).should be_true
+          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations).should be_truthy
         end
 
         it 'returns true when given association is part of the granting of a given privilege' do
-          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations).should be_true
+          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => @w.associations).should be_truthy
         end
 
         it 'returns false when given association is not part of the granting of a given privilege' do
           group2 = policy_machine.create_user_attribute('Group2')
 
           policy_machine.add_association(group2, Set.new([@w]), @writer, @project1)
-          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => [@w.associations.last]).should be_false
+          policy_machine.is_privilege?(@u1, @w, @o1, 'associations' => [@w.associations.last]).should be_falsey
         end
       end
 
@@ -632,16 +632,16 @@ shared_examples "a policy machine" do
         end
 
         it 'accepts in_user_attribute in options[:in_user_attribute]' do
-          policy_machine.is_privilege?(@u1, @w, @o1, :in_user_attribute => @group1).should be_true
+          policy_machine.is_privilege?(@u1, @w, @o1, :in_user_attribute => @group1).should be_truthy
         end
 
         it "accepts in_user_attribute in options['in_user_attribute']" do
-          policy_machine.is_privilege?(@group1, @w, @o1, 'in_user_attribute' => @group1).should be_true
+          policy_machine.is_privilege?(@group1, @w, @o1, 'in_user_attribute' => @group1).should be_truthy
         end
 
         it 'returns false if given user is not in given in_user_attribute' do
           group2 = policy_machine.create_user_attribute('Group2')
-          policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => group2).should be_false
+          policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => group2).should be_falsey
         end
       end
 
@@ -652,22 +652,22 @@ shared_examples "a policy machine" do
         end
 
         it 'accepts in_object_attribute in options[:in_object_attribute]' do
-          policy_machine.is_privilege?(@u1, @w, @o1, :in_object_attribute => @project1).should be_true
+          policy_machine.is_privilege?(@u1, @w, @o1, :in_object_attribute => @project1).should be_truthy
         end
 
         it "accepts in_object_attribute in options['in_object_attribute']" do
-          policy_machine.is_privilege?(@u1, @w, @project1, 'in_object_attribute' => @project1).should be_true
+          policy_machine.is_privilege?(@u1, @w, @project1, 'in_object_attribute' => @project1).should be_truthy
         end
 
         it 'returns false if given user is not in given in_object_attribute' do
           project2 = policy_machine.create_object_attribute('Project2')
-          policy_machine.is_privilege?(@u1, @w, @o1, 'in_object_attribute' => project2).should be_false
+          policy_machine.is_privilege?(@u1, @w, @o1, 'in_object_attribute' => project2).should be_falsey
         end
 
         it 'accepts both in_user_attribute and in_object_attribute' do
           project2 = policy_machine.create_object_attribute('Project2')
           policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => @group1, 'in_object_attribute' => project2).
-            should be_false
+            should be_falsey
         end
       end
     end

--- a/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
+++ b/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
@@ -10,12 +10,12 @@ shared_examples "a policy machine storage adapter" do
     describe "#add_#{pe_type}" do
       it 'stores the policy element' do
         src = policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid', 'some_policy_machine_uuid')
-        policy_machine_storage_adapter.element_in_machine?(src).should be_true
+        policy_machine_storage_adapter.element_in_machine?(src).should be_truthy
       end
 
       it 'returns the instantiated policy element with persisted attribute set to true' do
         node = policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid', 'some_policy_machine_uuid')
-        node.persisted.should be_true
+        node.persisted.should be_truthy
       end
     end
 
@@ -101,16 +101,16 @@ shared_examples "a policy machine storage adapter" do
     context 'source or destination node is of the Node type return by add_' do
       it 'assigns the nodes in one direction (from source to destination)' do
         policy_machine_storage_adapter.assign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@src, @dst).should be_true
+        policy_machine_storage_adapter.connected?(@src, @dst).should be_truthy
       end
 
       it 'does not connect the nodes from destination to source' do
         policy_machine_storage_adapter.assign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@dst, @src).should be_false
+        policy_machine_storage_adapter.connected?(@dst, @src).should be_falsey
       end
 
       it 'returns true' do
-        policy_machine_storage_adapter.assign(@src, @dst).should be_true
+        policy_machine_storage_adapter.assign(@src, @dst).should be_truthy
       end
     end
 
@@ -142,11 +142,11 @@ shared_examples "a policy machine storage adapter" do
 
     context 'source or destination node is of the Node type return by add_node' do
       it 'returns true if source and destination nodes are connected' do
-        policy_machine_storage_adapter.connected?(@src, @dst).should be_true
+        policy_machine_storage_adapter.connected?(@src, @dst).should be_truthy
       end
 
       it 'returns false if source and destination nodes are not connected' do
-        policy_machine_storage_adapter.connected?(@src, @internal2).should be_false
+        policy_machine_storage_adapter.connected?(@src, @internal2).should be_falsey
       end
     end
 
@@ -203,22 +203,22 @@ shared_examples "a policy machine storage adapter" do
     context 'source or destination node is of the Node type return by add_' do
       it 'disconnects source node from destination node' do
         policy_machine_storage_adapter.unassign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@src, @dst).should be_false
+        policy_machine_storage_adapter.connected?(@src, @dst).should be_falsey
       end
 
       it 'does not disconnect destination from source node if there is an assignment in that direction' do
         policy_machine_storage_adapter.assign(@dst, @src)
         policy_machine_storage_adapter.unassign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@dst, @src).should be_true
+        policy_machine_storage_adapter.connected?(@dst, @src).should be_truthy
       end
 
       it 'returns true on successful disconnection' do
-        policy_machine_storage_adapter.unassign(@src, @dst).should be_true
+        policy_machine_storage_adapter.unassign(@src, @dst).should be_truthy
       end
 
       it "returns false on unsuccessful disconnection (if the nodes weren't connected in the first place')" do
         policy_machine_storage_adapter.unassign(@src, @dst)
-        policy_machine_storage_adapter.unassign(@src, @dst).should be_false
+        policy_machine_storage_adapter.unassign(@src, @dst).should be_falsey
       end
     end
 
@@ -239,7 +239,7 @@ shared_examples "a policy machine storage adapter" do
     end
 
     it 'returns true when element is in machine' do
-      policy_machine_storage_adapter.element_in_machine?(@pe).should be_true
+      policy_machine_storage_adapter.element_in_machine?(@pe).should be_truthy
     end
   end
 
@@ -254,7 +254,7 @@ shared_examples "a policy machine storage adapter" do
     end
 
     it 'returns true' do
-      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1').should be_true
+      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1').should be_truthy
     end
 
     it 'stores the association' do

--- a/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
+++ b/spec/support/shared_examples_shared_examples_policy_machine_storage_adapter.rb
@@ -10,29 +10,29 @@ shared_examples "a policy machine storage adapter" do
     describe "#add_#{pe_type}" do
       it 'stores the policy element' do
         src = policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid', 'some_policy_machine_uuid')
-        policy_machine_storage_adapter.element_in_machine?(src).should be_truthy
+        expect(policy_machine_storage_adapter.element_in_machine?(src)).to be_truthy
       end
 
       it 'returns the instantiated policy element with persisted attribute set to true' do
         node = policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid', 'some_policy_machine_uuid')
-        node.persisted.should be_truthy
+        expect(node.persisted).to be_truthy
       end
     end
 
     describe "find_all_of_type_#{pe_type}" do
       it 'returns empty array if nothing found' do
-        policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}").should == []
+        expect(policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}")).to be_empty
       end
 
       it 'returns array of found policy elements of given type if one is found' do
         node = policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid', 'some_policy_machine_uuid')
-        policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}").should == [node]
+        expect(policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}")).to contain_exactly(node)
       end
 
       it 'returns array of found policy elements of given type if more than one is found' do
         node1 = policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid1', 'some_policy_machine_uuid')
         node2 = policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid2', 'some_policy_machine_uuid')
-        policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}").should match_array([node1, node2])
+        expect(policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}")).to contain_exactly(node1, node2)
       end
 
       context 'inclusions' do
@@ -41,8 +41,7 @@ shared_examples "a policy machine storage adapter" do
           policy_machine_storage_adapter.send("add_#{pe_type}", 'some_uuid2', 'some_policy_machine_uuid', tags: ['up', 'strange'])
         end
 
-        it 'requires an exact match on array attributes' do
-          pending('TODO, Rails unexpectedly does not automatically construct valid SQL here')
+        xit 'requires an exact match on array attributes' do
           expect(policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}", tags: ['down', 'up'])).to be_empty
           expect(policy_machine_storage_adapter.send("find_all_of_type_#{pe_type}", tags: ['up', 'down'])).to be_one
         end
@@ -101,16 +100,16 @@ shared_examples "a policy machine storage adapter" do
     context 'source or destination node is of the Node type return by add_' do
       it 'assigns the nodes in one direction (from source to destination)' do
         policy_machine_storage_adapter.assign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@src, @dst).should be_truthy
+        expect(policy_machine_storage_adapter.connected?(@src, @dst)).to be_truthy
       end
 
       it 'does not connect the nodes from destination to source' do
         policy_machine_storage_adapter.assign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@dst, @src).should be_falsey
+        expect(policy_machine_storage_adapter.connected?(@dst, @src)).to be_falsey
       end
 
       it 'returns true' do
-        policy_machine_storage_adapter.assign(@src, @dst).should be_truthy
+        expect(policy_machine_storage_adapter.assign(@src, @dst)).to be_truthy
       end
     end
 
@@ -142,11 +141,11 @@ shared_examples "a policy machine storage adapter" do
 
     context 'source or destination node is of the Node type return by add_node' do
       it 'returns true if source and destination nodes are connected' do
-        policy_machine_storage_adapter.connected?(@src, @dst).should be_truthy
+        expect(policy_machine_storage_adapter.connected?(@src, @dst)).to be_truthy
       end
 
       it 'returns false if source and destination nodes are not connected' do
-        policy_machine_storage_adapter.connected?(@src, @internal2).should be_falsey
+        expect(policy_machine_storage_adapter.connected?(@src, @internal2)).to be_falsey
       end
     end
 
@@ -203,22 +202,22 @@ shared_examples "a policy machine storage adapter" do
     context 'source or destination node is of the Node type return by add_' do
       it 'disconnects source node from destination node' do
         policy_machine_storage_adapter.unassign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@src, @dst).should be_falsey
+        expect(policy_machine_storage_adapter.connected?(@src, @dst)).to be_falsey
       end
 
       it 'does not disconnect destination from source node if there is an assignment in that direction' do
         policy_machine_storage_adapter.assign(@dst, @src)
         policy_machine_storage_adapter.unassign(@src, @dst)
-        policy_machine_storage_adapter.connected?(@dst, @src).should be_truthy
+        expect(policy_machine_storage_adapter.connected?(@dst, @src)).to be_truthy
       end
 
       it 'returns true on successful disconnection' do
-        policy_machine_storage_adapter.unassign(@src, @dst).should be_truthy
+        expect(policy_machine_storage_adapter.unassign(@src, @dst)).to be_truthy
       end
 
       it "returns false on unsuccessful disconnection (if the nodes weren't connected in the first place')" do
         policy_machine_storage_adapter.unassign(@src, @dst)
-        policy_machine_storage_adapter.unassign(@src, @dst).should be_falsey
+        expect(policy_machine_storage_adapter.unassign(@src, @dst)).to be_falsey
       end
     end
 
@@ -239,7 +238,7 @@ shared_examples "a policy machine storage adapter" do
     end
 
     it 'returns true when element is in machine' do
-      policy_machine_storage_adapter.element_in_machine?(@pe).should be_truthy
+      expect(policy_machine_storage_adapter.element_in_machine?(@pe)).to be_truthy
     end
   end
 
@@ -254,23 +253,23 @@ shared_examples "a policy machine storage adapter" do
     end
 
     it 'returns true' do
-      policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1').should be_truthy
+      expect(policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1')).to be_truthy
     end
 
     it 'stores the association' do
       policy_machine_storage_adapter.add_association(@ua, Set.new([@r, @w]), @reader_writer, @oa, 'some_policy_machine_uuid1')
       assocs_with_r = policy_machine_storage_adapter.associations_with(@r)
-      assocs_with_r.size.should eq 1
-      assocs_with_r[0][0].should == @ua
-      assocs_with_r[0][1].to_a.should match_array([@r, @w])
-      assocs_with_r[0][3].should == @oa
+      expect(assocs_with_r.size).to eq 1
+      expect(assocs_with_r[0][0]).to eq @ua
+      expect(assocs_with_r[0][1].to_a).to contain_exactly(@r, @w)
+      expect(assocs_with_r[0][3]).to eq @oa
 
       assocs_with_w = policy_machine_storage_adapter.associations_with(@w)
       assocs_with_w.size == 1
-      assocs_with_w[0][0].should == @ua
-      assocs_with_w[0][1].to_a.should match_array([@r, @w])
-      assocs_with_r[0][2].should == @reader_writer
-      assocs_with_r[0][3].should == @oa
+      expect(assocs_with_w[0][0]).to eq @ua
+      expect(assocs_with_w[0][1].to_a).to contain_exactly(@r, @w)
+      expect(assocs_with_r[0][2]).to eq @reader_writer
+      expect(assocs_with_r[0][3]).to eq @oa
     end
 
     xit 'overwrites a previously stored association' do
@@ -278,11 +277,11 @@ shared_examples "a policy machine storage adapter" do
       policy_machine_storage_adapter.add_association(@ua, Set.new([@r]), @reader, @oa, 'some_policy_machine_uuid1')
       assocs_with_r = policy_machine_storage_adapter.associations_with(@r)
       assocs_with_r.size == 1
-      assocs_with_r[0][0].should == @ua
-      assocs_with_r[0][1].to_a.should == [@r]
-      assocs_with_r[0][2].should == @oa
+      expect(assocs_with_r[0][0]).to eq @ua
+      expect(assocs_with_r[0][1].to_a).to contain_exactly(@r)
+      expect(assocs_with_r[0][2]).to eq @oa
 
-      policy_machine_storage_adapter.associations_with(@w).should == []
+      expect(policy_machine_storage_adapter.associations_with(@w)).to be_empty
     end
   end
 
@@ -299,7 +298,7 @@ shared_examples "a policy machine storage adapter" do
     end
 
     it 'returns empty array when given operation has no associated associations' do
-      policy_machine_storage_adapter.associations_with(@r).should == []
+      expect(policy_machine_storage_adapter.associations_with(@r)).to be_empty
     end
 
     it 'returns structured array when given operation has associated associations' do
@@ -308,14 +307,14 @@ shared_examples "a policy machine storage adapter" do
       assocs_with_w = policy_machine_storage_adapter.associations_with(@w)
 
       assocs_with_w.size == 2
-      assocs_with_w[0][0].should == @ua
-      assocs_with_w[0][1].to_a.should == [@w]
-      assocs_with_w[0][2].should == @writer
-      assocs_with_w[0][3].should == @oa
-      assocs_with_w[1][0].should == @ua2
-      assocs_with_w[1][1].to_a.should match_array([@w, @e])
-      assocs_with_w[1][2].should == @writer_editor
-      assocs_with_w[1][3].should == @oa
+      expect(assocs_with_w[0][0]).to eq @ua
+      expect(assocs_with_w[0][1].to_a).to contain_exactly(@w)
+      expect(assocs_with_w[0][2]).to eq @writer
+      expect(assocs_with_w[0][3]).to eq @oa
+      expect(assocs_with_w[1][0]).to eq @ua2
+      expect(assocs_with_w[1][1].to_a).to contain_exactly(@w, @e)
+      expect(assocs_with_w[1][2]).to eq @writer_editor
+      expect(assocs_with_w[1][3]).to eq @oa
 
     end
 
@@ -330,13 +329,13 @@ shared_examples "a policy machine storage adapter" do
     end
 
     it 'returns empty array if object is in no policy classes' do
-      policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa).should == []
+      expect(policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa)).to be_empty
     end
 
     it 'returns array of policy class(es) if object is in policy class(es)' do
       policy_machine_storage_adapter.assign(@oa, @pc1)
       policy_machine_storage_adapter.assign(@oa, @pc3)
-      policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa).should match_array([@pc1, @pc3])
+      expect(policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa)).to contain_exactly(@pc1, @pc3)
     end
 
     it 'handles non unique associations' do
@@ -354,7 +353,7 @@ shared_examples "a policy machine storage adapter" do
         @pc1 = policy_machine_storage_adapter.add_policy_class('some_pc1', 'some_policy_machine_uuid1')
         policy_machine_storage_adapter.assign(@oa, @pc1)
       end
-      policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa).should == [@pc1]
+      expect(policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa)).to contain_exactly(@pc1)
     end
 
     it 'rolls back the block on error' do
@@ -369,8 +368,8 @@ shared_examples "a policy machine storage adapter" do
           policy_machine_storage_adapter.assign(@oa, :invalid_policy_class)
         end
       end.to raise_error(ArgumentError)
-      policy_machine_storage_adapter.find_all_of_type_policy_class.should == [@pc1]
-      policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa).should == [@pc1]
+      expect(policy_machine_storage_adapter.find_all_of_type_policy_class).to contain_exactly(@pc1)
+      expect(policy_machine_storage_adapter.policy_classes_for_object_attribute(@oa)).to contain_exactly(@pc1)
     end
   end
 

--- a/spec/support/shared_examples_storage_adapter_public_methods.rb
+++ b/spec/support/shared_examples_storage_adapter_public_methods.rb
@@ -13,7 +13,7 @@ shared_examples "a policy machine storage adapter with required public methods" 
 
   required_public_methods.each do |req_public_method|
     it "responds to #{req_public_method}" do
-      policy_machine_storage_adapter.should respond_to(req_public_method)
+      expect(policy_machine_storage_adapter).to respond_to(req_public_method)
     end
   end
 


### PR DESCRIPTION
A long overdue upgrade to the current stable version of RSpec from v2.13. Enables more powerful comparators and the cleaner `expect` syntax for specs.

Also updates all `should` matchers to `expects` and utilizes the `contain_exactly` matcher where applicable.