### PR TITLE
Added optional filtering to descendants and ancestors methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.5.2
 * Upgrade RSpec dependency to version 3.5.0
+* Add optional filtering to descendants and ancestors methods in the ActiveRecord storage
+  adapter.
 
 ## 1.5.1
 * Fix a bug in some of the new import code that prevented operation policy

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -104,8 +104,8 @@ module PM
 
     # Delegates extra attribute reads to stored_pe
     def method_missing(meth, *args)
-      if args.none? && stored_pe.respond_to?(meth)
-        stored_pe.send(meth)
+      if stored_pe.respond_to?(meth)
+        stored_pe.send(meth, *args)
       else
         super
       end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -137,7 +137,15 @@ module PolicyMachineStorageAdapter
       end
 
       def descendants(filters = {})
-        Assignment.descendants_of(self).where(filters)
+        if filters.empty?
+          Assignment.descendants_of(self)
+        else
+          valid_filters = PolicyElement.columns_hash.map { |column| column.first.to_sym }
+          filters.each_key do |key|
+            raise(ArgumentError, "#{key} is not a valid filter") unless valid_filters.include?(key)
+          end
+          Assignment.descendants_of(self).where(filters)
+        end
       end
 
       def link_descendants
@@ -145,7 +153,15 @@ module PolicyMachineStorageAdapter
       end
 
       def ancestors(filters = {})
-        Assignment.ancestors_of(self).where(filters)
+        if filters.empty?
+          Assignment.ancestors_of(self)
+        else
+          valid_filters = PolicyElement.columns_hash.map { |column| column.first.to_sym }
+          filters.each_key do |key|
+            raise(ArgumentError, "#{key} is not a valid filter") unless valid_filters.include?(key)
+          end
+          Assignment.ancestors_of(self).where(filters)
+        end
       end
 
       def link_ancestors

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -137,27 +137,17 @@ module PolicyMachineStorageAdapter
       end
 
       def descendants(filters = {})
-        if filters.present?
-          valid_filters = PolicyElement.column_names
-          filters.stringify_keys.each_key do |key|
-            raise(ArgumentError, "#{key} is not a valid filter") unless valid_filters.include?(key)
-          end
-        end
+        assert_valid_filters!(filters)
         Assignment.descendants_of(self).where(filters)
+      end
+
+      def ancestors(filters = {})
+        assert_valid_filters!(filters)
+        Assignment.ancestors_of(self).where(filters)
       end
 
       def link_descendants
         LogicalLink.descendants_of(self)
-      end
-
-      def ancestors(filters = {})
-        if filters.present?
-          valid_filters = PolicyElement.column_names
-          filters.stringify_keys.each_key do |key|
-            raise(ArgumentError, "#{key} is not a valid filter") unless valid_filters.include?(key)
-          end
-        end
-        Assignment.ancestors_of(self).where(filters)
       end
 
       def link_ancestors
@@ -252,6 +242,13 @@ module PolicyMachineStorageAdapter
         end
       end
 
+      private
+
+      def assert_valid_filters!(filters)
+        unless (filters.keys - PolicyElement.column_names.map(&:to_sym)).empty?
+          raise ArgumentError, "Provided argument contains invalid keys, valid keys are #{PolicyElement.column_names}"
+        end
+      end
     end
 
     class User < PolicyElement

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -136,16 +136,16 @@ module PolicyMachineStorageAdapter
         self.class.store_accessor(:extra_attributes, @extra_attributes_hash.keys)
       end
 
-      def descendants
-        Assignment.descendants_of(self)
+      def descendants(filters = {})
+        Assignment.descendants_of(self).where(filters)
       end
 
       def link_descendants
         LogicalLink.descendants_of(self)
       end
 
-      def ancestors
-        Assignment.ancestors_of(self)
+      def ancestors(filters = {})
+        Assignment.ancestors_of(self).where(filters)
       end
 
       def link_ancestors

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -137,15 +137,13 @@ module PolicyMachineStorageAdapter
       end
 
       def descendants(filters = {})
-        if filters.empty?
-          Assignment.descendants_of(self)
-        else
-          valid_filters = PolicyElement.columns_hash.map { |column| column.first.to_sym }
-          filters.each_key do |key|
+        if filters.present?
+          valid_filters = PolicyElement.column_names
+          filters.stringify_keys.each_key do |key|
             raise(ArgumentError, "#{key} is not a valid filter") unless valid_filters.include?(key)
           end
-          Assignment.descendants_of(self).where(filters)
         end
+        Assignment.descendants_of(self).where(filters)
       end
 
       def link_descendants
@@ -153,15 +151,13 @@ module PolicyMachineStorageAdapter
       end
 
       def ancestors(filters = {})
-        if filters.empty?
-          Assignment.ancestors_of(self)
-        else
-          valid_filters = PolicyElement.columns_hash.map { |column| column.first.to_sym }
-          filters.each_key do |key|
+        if filters.present?
+          valid_filters = PolicyElement.column_names
+          filters.stringify_keys.each_key do |key|
             raise(ArgumentError, "#{key} is not a valid filter") unless valid_filters.include?(key)
           end
-          Assignment.ancestors_of(self).where(filters)
         end
+        Assignment.ancestors_of(self).where(filters)
       end
 
       def link_ancestors

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -419,13 +419,11 @@ describe 'ActiveRecord' do
 
         it 'applies a single filter if one is supplied' do
           green_descendants = @u1.descendants(color: 'green')
-          expect(green_descendants.size).to eq 2
           expect(green_descendants).to contain_exactly(@ua1.stored_pe, @new_ua.stored_pe)
         end
 
         it 'applies multiple filters if they are supplied' do
           green_descendants = @u1.descendants(color: 'green', unique_identifier: 'new_ua')
-          expect(green_descendants.size).to eq 1
           expect(green_descendants).to contain_exactly(@new_ua.stored_pe)
         end
 
@@ -469,13 +467,11 @@ describe 'ActiveRecord' do
 
         it 'applies a single filter if one is supplied' do
           blue_ancestors = @ua1.ancestors(color: 'blue')
-          expect(blue_ancestors.size).to eq 2
           expect(blue_ancestors).to contain_exactly(@u2.stored_pe, @u3.stored_pe)
         end
 
         it 'applies multiple filters if they are supplied' do
           blue_ancestors = @ua1.ancestors(color: 'blue', unique_identifier: 'u3')
-          expect(blue_ancestors.size).to eq 1
           expect(blue_ancestors).to contain_exactly(@u3.stored_pe)
         end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -428,6 +428,17 @@ describe 'ActiveRecord' do
           expect(green_descendants.size).to eq 1
           expect(green_descendants).to contain_exactly(@new_ua.stored_pe)
         end
+
+        it 'returns appropriate results when filters apply to no descendants' do
+          expect(@u1.descendants(color: 'taupe')).to be_empty
+          expect { @u1.descendants(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
+        end
+
+        it 'returns appropriate results when filters apply to all descendants' do
+          all_descendants = @user_attributes.map(&:stored_pe) + [@new_ua.stored_pe]
+          expect(@u1.descendants({})).to match_array(all_descendants)
+          expect(@u1.descendants(policy_machine_uuid: @pm.uuid)).to match_array(all_descendants)
+        end
       end
     end
 
@@ -466,6 +477,17 @@ describe 'ActiveRecord' do
           blue_ancestors = @ua1.ancestors(color: 'blue', unique_identifier: 'u3')
           expect(blue_ancestors.size).to eq 1
           expect(blue_ancestors).to contain_exactly(@u3.stored_pe)
+        end
+
+        it 'returns appropriate results when filters apply to no ancestors' do
+          expect(@ua1.ancestors(color: 'taupe')).to be_empty
+          expect { @ua1.ancestors(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
+        end
+
+        it 'returns appropriate results when filters apply to all ancestors' do
+          all_ancestors = [@u1.stored_pe, @u2.stored_pe, @u3.stored_pe]
+          expect(@ua1.ancestors({})).to match_array(all_ancestors)
+          expect(@ua1.ancestors(policy_machine_uuid: @pm.uuid)).to match_array(all_ancestors)
         end
       end
     end

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -665,8 +665,8 @@ shared_examples "a policy machine" do
 
         it 'accepts both in_user_attribute and in_object_attribute' do
           project2 = policy_machine.create_object_attribute('Project2')
-          policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => @group1, 'in_object_attribute' => project2).
-            should be_falsey
+          expect(policy_machine.is_privilege?(@u1, @w, @o1, 'in_user_attribute' => @group1, 'in_object_attribute' => project2))
+            .to be_falsey
         end
       end
     end


### PR DESCRIPTION
This PR adds optional attribute filtering to the ActiveRecord `descendants` and `ancestors` methods. This functions similarly to the `query` optional argument in the find methods, and helps limit memory overhead when a smaller subset of results is needed.

Also updates the `method_missing` in the core PolicyElement class to pass arguments through, rather than stripping them.


Finished in 1 minute 38.03 seconds (files took 0.90146 seconds to load)
1553 examples, 0 failures, 19 pending