### PR TITLE
Add optional filters to parents and children attribute accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.3
+* Add optional filtering to parents and children attribute accessors in the ActiveRecord storage
+  adapter.
+
 ## 1.5.2
 * Upgrade RSpec dependency to version 3.5.0
 * Add optional filtering to descendants and ancestors methods in the ActiveRecord storage

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -156,12 +156,12 @@ module PolicyMachineStorageAdapter
         super.where(filters)
       end
 
-      def link_descendants
+      def link_descendants(filters = {})
         assert_valid_filters!(filters)
         LogicalLink.descendants_of(self).where(filters)
       end
 
-      def link_ancestors
+      def link_ancestors(filters = {})
         assert_valid_filters!(filters)
         LogicalLink.ancestors_of(self).where(filters)
       end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -147,12 +147,8 @@ module PolicyMachineStorageAdapter
       end
 
       def parents(filters = {})
-        if filters.present?
-          assert_valid_filters!(filters)
-          super.where(filters)
-        else
-          super
-        end
+        assert_valid_filters!(filters)
+        super.where(filters)
       end
 
       def children(filters = {})

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -146,6 +146,16 @@ module PolicyMachineStorageAdapter
         Assignment.ancestors_of(self).where(filters)
       end
 
+      def parents(filters = {})
+        assert_valid_filters!(filters)
+        super.where(filters)
+      end
+
+      def children(filters = {})
+        assert_valid_filters!(filters)
+        super.where(filters)
+      end
+
       def link_descendants
         LogicalLink.descendants_of(self)
       end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -105,10 +105,10 @@ module PolicyMachineStorageAdapter
       has_many :filial_ties, class_name: 'Assignment', foreign_key: :child_id
       has_many :link_filial_ties, class_name: 'LogicalLink', foreign_key: :link_child_id
       # these don't actually destroy the relations, just the assignments
-      has_many :children, through: :assignments, dependent: :destroy
-      has_many :parents, through: :filial_ties, dependent: :destroy
-      has_many :link_children, through: :logical_links, dependent: :destroy
-      has_many :link_parents, through: :link_filial_ties, dependent: :destroy
+      has_many :unfiltered_children, through: :assignments, source: :child, dependent: :destroy
+      has_many :unfiltered_parents, through: :filial_ties, source: :parent, dependent: :destroy
+      has_many :unfiltered_link_children, through: :logical_links, source: :link_child, dependent: :destroy
+      has_many :unfiltered_link_parents, through: :link_filial_ties, source: :link_parent, dependent: :destroy
 
       attr_accessor :extra_attributes_hash
 
@@ -148,12 +148,12 @@ module PolicyMachineStorageAdapter
 
       def parents(filters = {})
         assert_valid_filters!(filters)
-        super.where(filters)
+        unfiltered_parents.where(filters)
       end
 
       def children(filters = {})
         assert_valid_filters!(filters)
-        super.where(filters)
+        unfiltered_children.where(filters)
       end
 
       def link_descendants(filters = {})
@@ -168,12 +168,12 @@ module PolicyMachineStorageAdapter
 
       def link_parents(filters = {})
         assert_valid_filters!(filters)
-        super.where(filters)
+        unfiltered_link_parents.where(filters)
       end
 
       def link_children(filters = {})
         assert_valid_filters!(filters)
-        super.where(filters)
+        unfiltered_link_children.where(filters)
       end
 
       def self.serialize(store:, name:, serializer: nil)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -147,8 +147,12 @@ module PolicyMachineStorageAdapter
       end
 
       def parents(filters = {})
-        assert_valid_filters!(filters)
-        super.where(filters)
+        if filters.present?
+          assert_valid_filters!(filters)
+          super.where(filters)
+        else
+          super
+        end
       end
 
       def children(filters = {})

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -157,11 +157,23 @@ module PolicyMachineStorageAdapter
       end
 
       def link_descendants
-        LogicalLink.descendants_of(self)
+        assert_valid_filters!(filters)
+        LogicalLink.descendants_of(self).where(filters)
       end
 
       def link_ancestors
-        LogicalLink.ancestors_of(self)
+        assert_valid_filters!(filters)
+        LogicalLink.ancestors_of(self).where(filters)
+      end
+
+      def link_parents(filters = {})
+        assert_valid_filters!(filters)
+        super.where(filters)
+      end
+
+      def link_children(filters = {})
+        assert_valid_filters!(filters)
+        super.where(filters)
       end
 
       def self.serialize(store:, name:, serializer: nil)

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "policy_machine"
-  s.version     = "1.5.2"
+  s.version     = "1.5.3"
   s.summary     = "Policy Machine!"
   s.description = "A ruby implementation of the Policy Machine authorization formalism."
   s.authors     = ['Matthew Szenher', 'Aaron Weiner']

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -411,7 +411,6 @@ describe 'ActiveRecord' do
       context 'a filter is applied' do
         before do
           @ua1.update(color: 'green')
-
           @new_ua = @pm.create_user_attribute('new_ua')
           @new_ua.update(color: 'green')
           @pm.add_assignment(@u1, @new_ua)
@@ -431,19 +430,39 @@ describe 'ActiveRecord' do
           expect(@u1.descendants(color: 'taupe')).to be_empty
           expect { @u1.descendants(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
         end
-
-        it 'returns appropriate results when filters apply to all descendants' do
-          all_descendants = @user_attributes.map(&:stored_pe) + [@new_ua.stored_pe]
-          expect(@u1.descendants({})).to match_array(all_descendants)
-          expect(@u1.descendants(policy_machine_uuid: @pm.uuid)).to match_array(all_descendants)
-        end
       end
     end
 
     describe '#link_descendants' do
-      it 'returns appropriate cross descendants' do
-        desc = [@pm2_u1.stored_pe, @pm2_op.stored_pe, @pm3_user_attribute.stored_pe]
-        expect(@u1.link_descendants).to match_array desc
+      context 'no filter is applied' do
+        it 'returns appropriate cross descendants one level deep' do
+          expect(@pm2_op.link_descendants).to contain_exactly(@pm3_user_attribute.stored_pe)
+        end
+
+        it 'returns appropriate cross descendants multiple levels deep' do
+          desc = [@pm2_u1.stored_pe, @pm2_op.stored_pe, @pm3_user_attribute.stored_pe]
+          expect(@u1.link_descendants).to match_array desc
+        end
+      end
+
+      context 'a filter is applied' do
+        before do
+          @pm2_u1.update(color: 'blue')
+          @pm2_op.update(color: 'blue')
+        end
+
+        it 'applies a single filter if one is supplied' do
+          expect(@u1.link_descendants(color: 'blue')).to contain_exactly(@pm2_u1.stored_pe, @pm2_op.stored_pe)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          expect(@u1.link_descendants(color: 'blue', unique_identifier: 'pm2 op')).to contain_exactly(@pm2_op.stored_pe)
+        end
+
+        it 'returns appropriate results when filters apply to no link_descendants' do
+          expect(@u1.link_descendants(color: 'taupe')).to be_empty
+          expect { @u1.link_descendants(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
+        end
       end
     end
 
@@ -456,45 +475,56 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         before do
+          @u1.update(color: 'blue')
           @u2 = @pm.create_user('u2')
           @u2.update(color: 'blue')
           @pm.add_assignment(@u2, @ua1)
-
-          @u3 = @pm.create_user('u3')
-          @u3.update(color: 'blue')
-          @pm.add_assignment(@u3, @ua1)
         end
 
         it 'applies a single filter if one is supplied' do
-          blue_ancestors = @ua1.ancestors(color: 'blue')
-          expect(blue_ancestors).to contain_exactly(@u2.stored_pe, @u3.stored_pe)
+          expect(@ua1.ancestors(color: 'blue')).to contain_exactly(@u1.stored_pe, @u2.stored_pe)
         end
 
         it 'applies multiple filters if they are supplied' do
-          blue_ancestors = @ua1.ancestors(color: 'blue', unique_identifier: 'u3')
-          expect(blue_ancestors).to contain_exactly(@u3.stored_pe)
+          expect(@ua1.ancestors(color: 'blue', unique_identifier: 'u2')).to contain_exactly(@u2.stored_pe)
         end
 
         it 'returns appropriate results when filters apply to no ancestors' do
           expect(@ua1.ancestors(color: 'taupe')).to be_empty
           expect { @ua1.ancestors(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
         end
-
-        it 'returns appropriate results when filters apply to all ancestors' do
-          all_ancestors = [@u1.stored_pe, @u2.stored_pe, @u3.stored_pe]
-          expect(@ua1.ancestors({})).to match_array(all_ancestors)
-          expect(@ua1.ancestors(policy_machine_uuid: @pm.uuid)).to match_array(all_ancestors)
-        end
       end
     end
 
     describe '#link_ancestors' do
-      it 'returns appropriate cross ancestors one level deep' do
-        expect(@pm2_u1.link_ancestors).to match_array [@u1.stored_pe]
+      context 'no filter is applied' do
+        it 'returns appropriate cross ancestors one level deep' do
+          expect(@pm2_u1.link_ancestors).to match_array [@u1.stored_pe]
+        end
+
+        it 'returns appropriate cross ancestors multiple levels deep' do
+          expect(@pm3_user_attribute.link_ancestors).to match_array [@pm2_op.stored_pe, @u1.stored_pe]
+        end
       end
 
-      it 'returns appropriate cross ancestors multiple levels deep' do
-        expect(@pm3_user_attribute.link_ancestors).to match_array [@pm2_op.stored_pe, @u1.stored_pe]
+      context 'a filter is applied' do
+        before do
+          @u1.update(color: 'blue')
+          @pm2_op.update(color: 'blue')
+        end
+
+        it 'applies a single filter if one is supplied' do
+          expect(@pm3_user_attribute.link_ancestors(color: 'blue')).to contain_exactly(@u1.stored_pe, @pm2_op.stored_pe)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          expect(@pm3_user_attribute.link_ancestors(color: 'blue', unique_identifier: 'pm2 op')).to contain_exactly(@pm2_op.stored_pe)
+        end
+
+        it 'returns appropriate results when filters apply to no link_ancestors' do
+          expect(@pm3_user_attribute.link_ancestors(color: 'taupe')).to be_empty
+          expect { @pm3_user_attribute.link_ancestors(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
+        end
       end
     end
 
@@ -508,11 +538,10 @@ describe 'ActiveRecord' do
       context 'a filter is applied' do
         before do
           @u2 = @pm.create_user('u2')
-          @u2.update(color: 'blue')
-          @pm.add_assignment(@u2, @ua1)
-
           @u3 = @pm.create_user('u3')
+          @u2.update(color: 'blue')
           @u3.update(color: 'blue')
+          @pm.add_assignment(@u2, @ua1)
           @pm.add_assignment(@u3, @ua1)
         end
 
@@ -528,18 +557,6 @@ describe 'ActiveRecord' do
           expect(@ua1.parents(color: 'taupe')).to be_empty
           expect { @ua1.parents(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
         end
-
-        it 'returns appropriate results when filters apply to all parents' do
-          all_parents = [@u1.stored_pe, @u2.stored_pe, @u3.stored_pe]
-          expect(@ua1.parents({})).to match_array(all_parents)
-          expect(@ua1.parents(policy_machine_uuid: @pm.uuid)).to match_array(all_parents)
-        end
-      end
-    end
-
-    describe '#link_parents' do
-      it 'returns appropriate parents' do
-        expect(@pm3_user_attribute.link_parents).to match_array [@pm2_op.stored_pe]
       end
     end
 
@@ -553,7 +570,6 @@ describe 'ActiveRecord' do
       context 'a filter is applied' do
         before do
           @ua1.update(color: 'green')
-
           @new_ua = @pm.create_user_attribute('new_ua')
           @new_ua.update(color: 'green')
           @pm.add_assignment(@u1, @new_ua)
@@ -571,18 +587,66 @@ describe 'ActiveRecord' do
           expect(@u1.children(color: 'taupe')).to be_empty
           expect { @u1.children(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
         end
+      end
+    end
 
-        it 'returns appropriate results when filters apply to all children' do
-          all_children = @user_attributes.map(&:stored_pe) + [@new_ua.stored_pe]
-          expect(@u1.children({})).to match_array(all_children)
-          expect(@u1.children(policy_machine_uuid: @pm.uuid)).to match_array(all_children)
+    describe '#link_parents' do
+      context 'no filter is applied' do
+        it 'returns appropriate parents' do
+          expect(@pm3_user_attribute.link_parents).to match_array [@pm2_op.stored_pe]
+        end
+      end
+
+      context 'a filter is applied' do
+        before do
+          @pm2_op.update(color: 'green')
+          @new_op = @pm2.create_operation('new_op')
+          @new_op.update(color: 'green')
+          @pm.add_link(@new_op, @pm3_user_attribute)
+        end
+
+        it 'applies a single filter if one is supplied' do
+          expect(@pm3_user_attribute.link_parents(color: 'green')).to contain_exactly(@pm2_op.stored_pe, @new_op.stored_pe)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          expect(@pm3_user_attribute.link_parents(color: 'green', unique_identifier: 'new_op')).to contain_exactly(@new_op.stored_pe)
+        end
+
+        it 'returns appropriate results when filters apply to no link_parents' do
+          expect(@pm3_user_attribute.link_parents(color: 'taupe')).to be_empty
+          expect { @pm3_user_attribute.link_parents(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
         end
       end
     end
 
     describe '#link_children' do
-      it 'returns appropriate children' do
-        expect(@u1.link_children).to match_array [@pm2_u1.stored_pe, @pm2_op.stored_pe]
+      context 'no filter is applied' do
+        it 'returns appropriate children' do
+          expect(@u1.link_children).to match_array [@pm2_u1.stored_pe, @pm2_op.stored_pe]
+        end
+      end
+
+      context 'a filter is applied' do
+        before do
+          @pm2_u1.update(color: 'green')
+          @new_ua = @pm2.create_user_attribute('new_ua')
+          @new_ua.update(color: 'green')
+          @pm.add_link(@u1, @new_ua)
+        end
+
+        it 'applies a single filter if one is supplied' do
+          expect(@u1.link_children(color: 'green')).to contain_exactly(@pm2_u1.stored_pe, @new_ua.stored_pe)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          expect(@u1.link_children(color: 'green', unique_identifier: 'new_ua')).to contain_exactly(@new_ua.stored_pe)
+        end
+
+        it 'returns appropriate results when filters apply to no link_children' do
+          expect(@u1.link_children(color: 'taupe')).to be_empty
+          expect { @u1.link_children(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
+        end
       end
     end
   end


### PR DESCRIPTION
In addition to the filters added to the `descendants` and `ancestors` methods, the `parents` and `children` attributes also need that functionality. 

Methodology is the same, adding `where` clauses to the ActiveRecord relations via chaining. Tests and version updated to match.