### PR TITLE
[MCC-305829] Give precedence to column accessors over extra_attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.4
+* Give precedence to column attribute accessors instead of extra_attributes during store_attributes memoization.
+
 ## 1.5.3
 * Add optional filtering to parents and children attribute accessors in the ActiveRecord storage
   adapter.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 module PolicyMachine
-  VERSION = "1.5.3"
+  VERSION = "1.5.4"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -132,8 +132,10 @@ module PolicyMachineStorageAdapter
 
       # Uses ActiveRecord's store method to methodize new attribute keys in extra_attributes
       def store_attributes
+        # Do not overwrite accessors for existing columns
         @extra_attributes_hash = extra_attributes
-        self.class.store_accessor(:extra_attributes, @extra_attributes_hash.keys)
+        column_attributes = PolicyElement.column_names.map(&:to_sym)
+        self.class.store_accessor(:extra_attributes, @extra_attributes_hash.except(column_attributes).keys)
       end
 
       def descendants(filters = {})

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "policy_machine"
-  s.version     = "1.5.3"
+  s.version     = "1.5.4"
   s.summary     = "Policy Machine!"
   s.description = "A ruby implementation of the Policy Machine authorization formalism."
   s.authors     = ['Matthew Szenher', 'Aaron Weiner']

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -344,6 +344,15 @@ describe 'ActiveRecord' do
         expect(@o1.foo).to eq 'bar'
       end
 
+      it 'gives precedence to the column accessor' do
+        @o1.color = 'Color via column'
+        @o1.extra_attributes = { color: 'Color via extra_attributes' }
+        @o1.save
+
+        expect(@o1.color).to eq 'Color via column'
+        expect(policy_machine_storage_adapter.find_all_of_type_object(color: 'Color via column')).to contain_exactly(@o1)
+        expect(policy_machine_storage_adapter.find_all_of_type_object(color: 'Color via extra_attributes')).to be_empty
+      end
     end
 
     context 'when there is a lot of data' do

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1180,7 +1180,7 @@ shared_examples "a policy machine" do
       end
 
       context 'but given config options' do
-        it 'resepects batch size configs while return all results' do
+        it 'respects batch size configs while return all results' do
           enum = policy_machine.batch_find(type: :object, config: { batch_size: 3})
           results = enum.flat_map do |batch|
             expect(batch.size).to eq 3
@@ -1195,7 +1195,6 @@ shared_examples "a policy machine" do
   end
 
   describe 'batch_pluck' do
-
     before do
       @one_fish = policy_machine.create_object('one:fish')
       @two_fish = policy_machine.create_object('two:fish')
@@ -1220,10 +1219,11 @@ shared_examples "a policy machine" do
         end
 
         it 'does not return non-specified attributes' do
-          policy_machine.batch_pluck(type: :object, query: { unique_identifier: 'blue:one' }, fields: [:color]) do |batch|
+          policy_machine.batch_pluck(type: :object, query: { unique_identifier: 'blue:one' }, fields: [:unique_identifier]) do |batch|
             expect(batch.size).to eq 1
-            expect(batch.first[:color]).to eq 'blue'
-            expect(batch.first).not_to have_key(:unique_identifier)
+            expect(batch.first[:unique_identifier]).to eq 'blue:one'
+            expect(batch.first).not_to have_key(:type)
+            expect(batch.first).not_to have_key(:color)
           end
         end
       end


### PR DESCRIPTION
`store_attributes` previously would overwrite accessors for actual columns with extra_attributes accessors when there was a conflict. This PR gives precedence to the column accessors, only defining accessors for non-existent attributes.