### PR TITLE
pluck_parents and pluck_children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0
+* Add pluck_parents and pluck_children methods to ActiveRecord storage adapter.
+
 ## 1.5.4
 * Give precedence to column attribute accessors instead of extra_attributes during store_attributes memoization.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 module PolicyMachine
-  VERSION = "1.5.4"
+  VERSION = "1.6.0"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -178,6 +178,16 @@ module PolicyMachineStorageAdapter
         unfiltered_link_children.where(filters)
       end
 
+      def pluck_descendants(fields:, filters: {})
+        assert_valid_filters!(filters)
+        Assignment.descendants_of(self).where(filters).pluck(*fields)
+      end
+
+      def pluck_ancestors(fields:, filters: {})
+        assert_valid_filters!(filters)
+        Assignment.ancestors_of(self).where(filters).pluck(*fields)
+      end
+
       def pluck_parents(fields:, filters: {})
         assert_valid_filters!(filters)
         unfiltered_parents.where(filters).pluck(*fields)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -710,7 +710,6 @@ module PolicyMachineStorageAdapter
       permitting_oas = PolicyElement.where(id: operation.policy_element_associations.where(
         user_attribute_id: user_or_attribute.descendants | [user_or_attribute],
       ).select(:object_attribute_id))
-
       direct_scope = permitting_oas.where(type: class_for_type('object'))
       indirect_scope = Assignment.ancestors_of(permitting_oas).where(type: class_for_type('object'))
       if inclusion = options[:includes]

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "policy_machine"
-  s.version     = "1.5.4"
+  s.version     = "1.6.0"
   s.summary     = "Policy Machine!"
   s.description = "A ruby implementation of the Policy Machine authorization formalism."
   s.authors     = ['Matthew Szenher', 'Aaron Weiner']


### PR DESCRIPTION
This PR adds `pluck_parents` and `pluck_children` methods to the ActiveRecord storage adapter. These filtered graph traversals only return specified fields from the records, eliminating potentially unneeded overhead.

This will increment the version of the PolicyMachine to 1.6.0, reflecting new functionality.