### PR TITLE
[MCC-???] use existing version file instead of string in gemspec

### DIFF
--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
-module PolicyMachine
+class PolicyMachine
   VERSION = "1.5.4"
 end

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -1,6 +1,8 @@
+require_relative './lib/policy_machine/version'
+
 Gem::Specification.new do |s|
   s.name        = "policy_machine"
-  s.version     = "1.5.4"
+  s.version     = PolicyMachine::VERSION
   s.summary     = "Policy Machine!"
   s.description = "A ruby implementation of the Policy Machine authorization formalism."
   s.authors     = ['Matthew Szenher', 'Aaron Weiner']


### PR DESCRIPTION
pretty much says it all on the tin.  Switched the unloaded module declaration to a class declaration since it conflicts with the class load later