### PR TITLE
[MCC-317560] Graph pluck via method chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.2
+* Add pluck_from method family to the ActiveRecord storage adapter.
+
 ## 1.6.1
 * Fix a bug in the active record adapter's accessible_objects method preventing it from returing the correct operation set ids.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.6.1"
+  VERSION = "1.6.2"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -178,6 +178,30 @@ module PolicyMachineStorageAdapter
         unfiltered_link_children.where(filters)
       end
 
+      def pluck_from_descendants(filters: {}, fields:)
+        assert_valid_filters!(filters)
+
+        plucked_values = Assignment.descendants_of(self).where(filters).pluck(*fields.map(&:to_sym))
+
+        if fields.size > 1
+          plucked_values.map { |val| Hash[fields.zip(val)] }
+        else
+          plucked_values.map { |val| { fields.first.to_sym => val } }
+        end
+      end
+
+      def pluck_from_ancestors(filters: {}, fields:)
+        assert_valid_filters!(filters)
+
+        plucked_values = Assignment.ancestors_of(self).where(filters).pluck(*fields.map(&:to_sym))
+
+        if fields.size > 1
+          plucked_values.map { |val| Hash[fields.zip(val)] }
+        else
+          plucked_values.map { |val| { fields.first.to_sym => val } }
+        end
+      end
+
       def self.serialize(store:, name:, serializer: nil)
         active_record_serialize store, serializer
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -191,6 +191,8 @@ module PolicyMachineStorageAdapter
         link_children
       ).each do |graph_method|
         define_method("pluck_from_#{graph_method}") do |filters: {}, fields:|
+          raise(ArgumentError.new("Must provide at least one field to pluck")) unless fields.present?
+
           assert_valid_attributes!(filters.keys)
           assert_valid_attributes!(fields)
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -470,6 +470,10 @@ describe 'ActiveRecord' do
           expect { expect(user_1.pluck_from_descendants(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
         end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(user_1.pluck_from_descendants(fields: [])) }.to raise_error(ArgumentError)
+        end
       end
 
       context 'a filter is applied' do
@@ -562,6 +566,10 @@ describe 'ActiveRecord' do
           expect { expect(user_attr_1.pluck_from_ancestors(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
         end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(user_attr_1.pluck_from_ancestors(fields: [])) }.to raise_error(ArgumentError)
+        end
       end
 
       context 'a filter is applied' do
@@ -573,7 +581,7 @@ describe 'ActiveRecord' do
 
         it 'applies multiple filters if they are supplied' do
           args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_1', color: 'blue' } }
-          expect(user_attr_1.pluck_from_ancestors(args)).to contain_exactly({ unique_identifier: 'user_1' })
+          expect(user_attr_1.pluck_from_ancestors(args)).to contain_exactly(unique_identifier: 'user_1')
         end
 
         it 'returns appropriate results when filters apply to no ancestors' do
@@ -653,6 +661,10 @@ describe 'ActiveRecord' do
           expect { expect(user_attr_1.pluck_from_parents(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
         end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(user_attr_1.pluck_from_parents(fields: [])) }.to raise_error(ArgumentError)
+        end
       end
 
       context 'a filter is applied' do
@@ -714,6 +726,10 @@ describe 'ActiveRecord' do
         it 'errors appropriately when nonexistent attributes are specified' do
           expect { expect(user_1.pluck_from_children(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
+        end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(user_1.pluck_from_children(fields: [])) }.to raise_error(ArgumentError)
         end
       end
 
@@ -778,6 +794,10 @@ describe 'ActiveRecord' do
         it 'errors appropriately when nonexistent attributes are specified' do
           expect { expect(pm3_user_attr.pluck_from_link_parents(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
+        end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(pm3_user_attr.pluck_from_link_parents(fields: [])) }.to raise_error(ArgumentError)
         end
       end
 
@@ -844,6 +864,10 @@ describe 'ActiveRecord' do
         it 'errors appropriately when nonexistent attributes are specified' do
           expect { expect(user_1.pluck_from_link_children(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
+        end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(user_1.pluck_from_link_children(fields: [])) }.to raise_error(ArgumentError)
         end
       end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -451,6 +451,45 @@ describe 'ActiveRecord' do
       end
     end
 
+    describe '#pluck_from_descendants' do
+      context 'no filter is applied' do
+        it 'returns appropriate descendants and the specified attribute' do
+          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          expect(user_1.pluck_from_descendants(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate descendants and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'user_attr_1', color: 'green' },
+            { unique_identifier: 'user_attr_2', color: 'green' },
+            { unique_identifier: 'user_attr_3', color: 'green' }]
+          expect(user_1.pluck_from_descendants(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(user_1.pluck_from_descendants(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          expect(user_1.pluck_from_descendants(fields: [:color], filters: { color: 'green' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_attr_1', color: 'green' } }
+          expect(user_1.pluck_from_descendants(args)).to contain_exactly({ unique_identifier: 'user_attr_1' })
+        end
+
+        it 'returns appropriate results when filters apply to no descendants' do
+          expect(user_1.pluck_from_descendants(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
+        end
+      end
+    end
+
     describe '#link_descendants' do
       context 'no filter is applied' do
         it 'returns appropriate cross descendants one level deep' do
@@ -500,11 +539,6 @@ describe 'ActiveRecord' do
         it 'returns appropriate results when filters apply to no ancestors' do
           expect(user_attr_1.ancestors(color: 'taupe')).to be_empty
           expect { user_attr_1.ancestors(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
-        end
-
-        it 'pluck_from_ancestors' do
-          result = @ua1.pluck_from_ancestors(filters: { color: 'blue' }, fields: [:unique_identifier])
-          expect(result).to contain_exactly({ unique_identifier: "u1" }, { unique_identifier: "u2" })
         end
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -543,6 +543,45 @@ describe 'ActiveRecord' do
       end
     end
 
+    describe '#pluck_from_ancestors' do
+      context 'no filter is applied' do
+        it 'returns appropriate ancestors and the specified attribute' do
+          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          expect(user_attr_1.pluck_from_ancestors(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate ancestors and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'user_1', color: 'blue' },
+            { unique_identifier: 'user_2', color: 'blue' },
+            { unique_identifier: 'user_3', color: 'blue' }]
+          expect(user_attr_1.pluck_from_ancestors(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(user_attr_1.pluck_from_ancestors(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          expect(user_attr_1.pluck_from_ancestors(fields: [:color], filters: { color: 'blue' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_1', color: 'blue' } }
+          expect(user_attr_1.pluck_from_ancestors(args)).to contain_exactly({ unique_identifier: 'user_1' })
+        end
+
+        it 'returns appropriate results when filters apply to no ancestors' do
+          expect(user_attr_1.pluck_from_ancestors(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
+        end
+      end
+    end
+
     describe '#link_ancestors' do
       context 'no filter is applied' do
         it 'returns appropriate cross ancestors one level deep' do
@@ -595,6 +634,45 @@ describe 'ActiveRecord' do
       end
     end
 
+    describe '#pluck_from_parents' do
+      context 'no filter is applied' do
+        it 'returns appropriate parents and the specified attribute' do
+          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          expect(user_attr_1.pluck_from_parents(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate parents and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'user_1', color: 'blue' },
+            { unique_identifier: 'user_2', color: 'blue' },
+            { unique_identifier: 'user_3', color: 'blue' }]
+          expect(user_attr_1.pluck_from_parents(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(user_attr_1.pluck_from_parents(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          expect(user_attr_1.pluck_from_parents(fields: [:color], filters: { color: 'blue' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_1', color: 'blue' } }
+          expect(user_attr_1.pluck_from_parents(args)).to contain_exactly({ unique_identifier: 'user_1' })
+        end
+
+        it 'returns appropriate results when filters apply to no parents' do
+          expect(user_attr_1.pluck_from_parents(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
+        end
+      end
+    end
+
     describe '#children' do
       context 'no filter is applied' do
         it 'returns appropriate children' do
@@ -614,6 +692,45 @@ describe 'ActiveRecord' do
         it 'returns appropriate results when filters apply to no children' do
           expect(user_1.children(color: 'taupe')).to be_empty
           expect { user_1.children(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe '#pluck_from_children' do
+      context 'no filter is applied' do
+        it 'returns appropriate children and the specified attribute' do
+          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          expect(user_1.pluck_from_children(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate children and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'user_attr_1', color: 'green' },
+            { unique_identifier: 'user_attr_2', color: 'green' },
+            { unique_identifier: 'user_attr_3', color: 'green' }]
+          expect(user_1.pluck_from_children(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(user_1.pluck_from_children(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          expect(user_1.pluck_from_children(fields: [:color], filters: { color: 'green' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_attr_1', color: 'green' } }
+          expect(user_1.pluck_from_children(args)).to contain_exactly({ unique_identifier: 'user_attr_1' })
+        end
+
+        it 'returns appropriate results when filters apply to no children' do
+          expect(user_1.pluck_from_children(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
         end
       end
     end
@@ -644,6 +761,44 @@ describe 'ActiveRecord' do
       end
     end
 
+    describe '#pluck_from_link_parents' do
+      context 'no filter is applied' do
+        it 'returns appropriate link_parents and the specified attribute' do
+          plucked_results = [{ color: 'red' }, { color: 'red' }]
+          expect(pm3_user_attr.pluck_from_link_parents(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate link_parents and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'pm2_operation_1', color: 'red' },
+            { unique_identifier: 'pm2_operation_2', color: 'red' }]
+          expect(pm3_user_attr.pluck_from_link_parents(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(pm3_user_attr.pluck_from_link_parents(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'red' }, { color: 'red' }]
+          expect(pm3_user_attr.pluck_from_link_parents(fields: [:color], filters: { color: 'red' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'pm2_operation_1', color: 'red' } }
+          expect(pm3_user_attr.pluck_from_link_parents(args)).to contain_exactly({ unique_identifier: 'pm2_operation_1' })
+        end
+
+        it 'returns appropriate results when filters apply to no link_parents' do
+          expect(pm3_user_attr.pluck_from_link_parents(fields: [:unique_identifier], filters: { color: 'blue' })).to be_empty
+        end
+      end
+    end
+
     describe '#link_children' do
       context 'no filter is applied' do
         it 'returns appropriate children' do
@@ -666,6 +821,46 @@ describe 'ActiveRecord' do
         it 'returns appropriate results when filters apply to no link_children' do
           expect(user_1.link_children(color: 'taupe')).to be_empty
           expect { user_1.link_children(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe '#pluck_from_link_children' do
+      context 'no filter is applied' do
+        it 'returns appropriate link_children and the specified attribute' do
+          plucked_results = [{ color: 'blue' }, { color: 'red' }, { color: 'red' }, { color: 'green' }]
+          expect(user_1.pluck_from_link_children(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate link_children and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'pm2_user', color: 'blue' },
+            { unique_identifier: 'pm2_operation_1', color: 'red' },
+            { unique_identifier: 'pm2_operation_2', color: 'red' },
+            { unique_identifier: 'pm2_user_attr', color: 'green' }]
+          expect(user_1.pluck_from_link_children(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(user_1.pluck_from_link_children(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'green' }]
+          expect(user_1.pluck_from_link_children(fields: [:color], filters: { color: 'green' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'pm2_user', color: 'blue' } }
+          expect(user_1.pluck_from_link_children(args)).to contain_exactly({ unique_identifier: 'pm2_user' })
+        end
+
+        it 'returns appropriate results when filters apply to no link_children' do
+          expect(user_1.pluck_from_link_children(fields: [:unique_identifier], filters: { color: 'chartreuse' })).to be_empty
         end
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -486,6 +486,11 @@ describe 'ActiveRecord' do
           expect(@ua1.ancestors(color: 'taupe')).to be_empty
           expect { @ua1.ancestors(not_a_real_attribute: 'fake') }.to raise_error(ArgumentError)
         end
+
+        it 'pluck_from_ancestors' do
+          result = @ua1.pluck_from_ancestors(filters: { color: 'blue' }, fields: [:unique_identifier])
+          expect(result).to contain_exactly({ unique_identifier: "u1" }, { unique_identifier: "u2" })
+        end
       end
     end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -396,6 +396,15 @@ describe 'ActiveRecord' do
     let(:pm2_operation_2) { pm2.create_operation('pm2_operation_2') }
     let(:pm3_user_attr) { pm3.create_user_attribute('pm3_user_attr') }
 
+    # For specs that require more attribute differentiation for filtering
+    let(:darken_colors) do
+      ->{
+        user_2.update(color: 'navy_blue')
+        user_attr_2.update(color: 'forest_green')
+        pm2_operation_2.update(color: 'crimson')
+      }
+    end
+
     before do
       user_attributes.each { |ua| pm1.add_assignment(user_1, ua) }
       pm1.add_assignment(user_attr_1, user_attr_2)
@@ -452,16 +461,18 @@ describe 'ActiveRecord' do
     end
 
     describe '#pluck_from_descendants' do
+      before { darken_colors.call }
+
       context 'no filter is applied' do
         it 'returns appropriate descendants and the specified attribute' do
-          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          plucked_results = [{ color: 'green' }, { color: 'forest_green' }, { color: 'green' }]
           expect(user_1.pluck_from_descendants(fields: [:color])).to match_array(plucked_results)
         end
 
         it 'returns appropriate descendants and multiple specified attributes' do
           plucked_results = [
             { unique_identifier: 'user_attr_1', color: 'green' },
-            { unique_identifier: 'user_attr_2', color: 'green' },
+            { unique_identifier: 'user_attr_2', color: 'forest_green' },
             { unique_identifier: 'user_attr_3', color: 'green' }]
           expect(user_1.pluck_from_descendants(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
@@ -478,7 +489,7 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
-          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          plucked_results = [{ color: 'green' }, { color: 'green' }]
           expect(user_1.pluck_from_descendants(fields: [:color], filters: { color: 'green' }))
             .to match_array(plucked_results)
         end
@@ -548,16 +559,18 @@ describe 'ActiveRecord' do
     end
 
     describe '#pluck_from_ancestors' do
+      before { darken_colors.call }
+
       context 'no filter is applied' do
         it 'returns appropriate ancestors and the specified attribute' do
-          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          plucked_results = [{ color: 'blue' }, { color: 'navy_blue' }, { color: 'blue' }]
           expect(user_attr_1.pluck_from_ancestors(fields: [:color])).to match_array(plucked_results)
         end
 
         it 'returns appropriate ancestors and multiple specified attributes' do
           plucked_results = [
             { unique_identifier: 'user_1', color: 'blue' },
-            { unique_identifier: 'user_2', color: 'blue' },
+            { unique_identifier: 'user_2', color: 'navy_blue' },
             { unique_identifier: 'user_3', color: 'blue' }]
           expect(user_attr_1.pluck_from_ancestors(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
@@ -574,7 +587,7 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
-          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          plucked_results = [{ color: 'blue' }, { color: 'blue' }]
           expect(user_attr_1.pluck_from_ancestors(fields: [:color], filters: { color: 'blue' }))
             .to match_array(plucked_results)
         end
@@ -643,16 +656,18 @@ describe 'ActiveRecord' do
     end
 
     describe '#pluck_from_parents' do
+      before { darken_colors.call }
+
       context 'no filter is applied' do
         it 'returns appropriate parents and the specified attribute' do
-          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          plucked_results = [{ color: 'blue' }, { color: 'navy_blue' }, { color: 'blue' }]
           expect(user_attr_1.pluck_from_parents(fields: [:color])).to match_array(plucked_results)
         end
 
         it 'returns appropriate parents and multiple specified attributes' do
           plucked_results = [
             { unique_identifier: 'user_1', color: 'blue' },
-            { unique_identifier: 'user_2', color: 'blue' },
+            { unique_identifier: 'user_2', color: 'navy_blue' },
             { unique_identifier: 'user_3', color: 'blue' }]
           expect(user_attr_1.pluck_from_parents(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
@@ -669,7 +684,7 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
-          plucked_results = [{ color: 'blue' }, { color: 'blue' }, { color: 'blue' }]
+          plucked_results = [{ color: 'blue' }, { color: 'blue' }]
           expect(user_attr_1.pluck_from_parents(fields: [:color], filters: { color: 'blue' }))
             .to match_array(plucked_results)
         end
@@ -709,16 +724,18 @@ describe 'ActiveRecord' do
     end
 
     describe '#pluck_from_children' do
+      before { darken_colors.call }
+
       context 'no filter is applied' do
         it 'returns appropriate children and the specified attribute' do
-          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          plucked_results = [{ color: 'green' }, { color: 'forest_green' }, { color: 'green' }]
           expect(user_1.pluck_from_children(fields: [:color])).to match_array(plucked_results)
         end
 
         it 'returns appropriate children and multiple specified attributes' do
           plucked_results = [
             { unique_identifier: 'user_attr_1', color: 'green' },
-            { unique_identifier: 'user_attr_2', color: 'green' },
+            { unique_identifier: 'user_attr_2', color: 'forest_green' },
             { unique_identifier: 'user_attr_3', color: 'green' }]
           expect(user_1.pluck_from_children(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
@@ -735,7 +752,7 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
-          plucked_results = [{ color: 'green' }, { color: 'green' }, { color: 'green' }]
+          plucked_results = [{ color: 'green' }, { color: 'green' }]
           expect(user_1.pluck_from_children(fields: [:color], filters: { color: 'green' }))
             .to match_array(plucked_results)
         end
@@ -778,16 +795,18 @@ describe 'ActiveRecord' do
     end
 
     describe '#pluck_from_link_parents' do
+      before { darken_colors.call }
+
       context 'no filter is applied' do
         it 'returns appropriate link_parents and the specified attribute' do
-          plucked_results = [{ color: 'red' }, { color: 'red' }]
+          plucked_results = [{ color: 'red' }, { color: 'crimson' }]
           expect(pm3_user_attr.pluck_from_link_parents(fields: [:color])).to match_array(plucked_results)
         end
 
         it 'returns appropriate link_parents and multiple specified attributes' do
           plucked_results = [
             { unique_identifier: 'pm2_operation_1', color: 'red' },
-            { unique_identifier: 'pm2_operation_2', color: 'red' }]
+            { unique_identifier: 'pm2_operation_2', color: 'crimson' }]
           expect(pm3_user_attr.pluck_from_link_parents(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
 
@@ -803,7 +822,7 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
-          plucked_results = [{ color: 'red' }, { color: 'red' }]
+          plucked_results = [{ color: 'red' }]
           expect(pm3_user_attr.pluck_from_link_parents(fields: [:color], filters: { color: 'red' }))
             .to match_array(plucked_results)
         end
@@ -846,9 +865,11 @@ describe 'ActiveRecord' do
     end
 
     describe '#pluck_from_link_children' do
+      before { darken_colors.call }
+
       context 'no filter is applied' do
         it 'returns appropriate link_children and the specified attribute' do
-          plucked_results = [{ color: 'blue' }, { color: 'red' }, { color: 'red' }, { color: 'green' }]
+          plucked_results = [{ color: 'blue' }, { color: 'red' }, { color: 'crimson' }, { color: 'green' }]
           expect(user_1.pluck_from_link_children(fields: [:color])).to match_array(plucked_results)
         end
 
@@ -856,7 +877,7 @@ describe 'ActiveRecord' do
           plucked_results = [
             { unique_identifier: 'pm2_user', color: 'blue' },
             { unique_identifier: 'pm2_operation_1', color: 'red' },
-            { unique_identifier: 'pm2_operation_2', color: 'red' },
+            { unique_identifier: 'pm2_operation_2', color: 'crimson' },
             { unique_identifier: 'pm2_user_attr', color: 'green' }]
           expect(user_1.pluck_from_link_children(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end


### PR DESCRIPTION
This PR contains the trivial implementation of plucking attributes from PolicyElement relatives. It literally chains `pluck` onto the end of the other methods, then zips the result with the attribute names, leading to a result of the form...

```
[{ name: 'bob', profession: 'spartan' }, { name: 'wirt', profession: 'frog' }
```

Please review.
