### PR TITLE
[MCC-343261] Pluck ancestor tree with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.0
+* Add pluck_ancestor_tree method to ActiveRecord storage adapter.
+
 ## 1.6.2
 * Add pluck_from method family to the ActiveRecord storage adapter.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.6.2"
+  VERSION = "1.7.0"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -221,8 +221,8 @@ module PolicyMachineStorageAdapter
           memo[row['id']] = ancestor_array
         end
 
-        # (2) Add :id and :unique_identifier fields to all plucks
-        #     remove the root node's id from the ids-to-pluck, as it may not pass the filter
+        # (2) Add :id and :unique_identifier fields to the pluck; and remove the root node's id
+        #     from the ids-to-pluck, as it may not satisfy the filter
         id_tree.delete(id.to_s)
         fields_to_pluck = [:id, :unique_identifier] | fields
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -227,11 +227,11 @@ module PolicyMachineStorageAdapter
         fields_to_pluck = [:id, :unique_identifier] | fields
 
         # (3) Database call number 2: pluck the specified fields from the root node's ancestors
-        policy_element_attrs = PolicyElement.where(id: id_tree.keys).where(filters).pluck(*fields_to_pluck)
-        attribute_fields = fields_to_pluck - [:id]
+        plucked_policy_elements = PolicyElement.where(id: id_tree.keys).where(filters).pluck(*fields_to_pluck)
 
         # (4) Convert the plucked attributes into an attribute hash and merge it into the id subtree
-        policy_element_attrs.each do |policy_element|
+        attribute_fields = fields_to_pluck - [:id]
+        plucked_policy_elements.each do |policy_element|
           pe_id = policy_element[0].to_s
           # Convert [1, "blue", "user_1"] into { color: "blue", uuid: "user_1" }
           attribute_hash = HashWithIndifferentAccess[attribute_fields.zip(policy_element.drop(1))]

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -207,6 +207,90 @@ module PolicyMachineStorageAdapter
         end
       end
 
+      def pluck_attributes_from_ancestors(filters: {}, fields:)
+        assert_valid_attributes!(filters.keys)
+        assert_valid_attributes!(fields)
+
+        id_tree = Assignment.select_ancestor_ids([id]).each_with_object({}) do |row, memo|
+          ancestor_array = row['ancestor_ids'].tr('{}','').split(',')
+          ancestor_array.each { |ancestor_id| memo[ancestor_id] ||= [] }
+          memo[row['id']] = ancestor_array
+        end
+
+        id_tree.delete(id.to_s)
+
+        fields_to_pluck = [:id, :unique_identifier] | fields
+        pes = PolicyElement.where(id: id_tree.keys).where(filters).pluck(*fields_to_pluck)
+        fields_except_id = fields_to_pluck - [:id]
+
+        pes.each do |pe|
+          pe_id = pe[0].to_s
+          # Transmute [1, "blue", "user_1"] into { color: "blue", uuid: "user_1" }
+          attribute_hash = HashWithIndifferentAccess[fields_except_id.zip(pe.drop(1))]
+          id_tree[pe_id] = { ancestor_ids: id_tree[pe_id] }.merge(attribute_hash)
+        end
+
+        id_tree.each do |pe_id, pe_attrs|
+          if pe_attrs.empty?
+            id_tree.delete(pe_id)
+          else
+            pe_attrs[:ancestor_attributes] =
+              pe_attrs[:ancestor_ids].map do |ancestor_id|
+                if id_tree[ancestor_id]
+                  id_tree[ancestor_id].except(:ancestor_ids)
+                else
+                  {}
+                end
+              end
+            pe_attrs.delete_if { |key,_| [:unique_identifier, :ancestor_attributes].exclude?(key) }
+          end
+        end
+
+        id_tree.values
+      end
+
+      def pluck_attributes_from_descendants(filters: {}, fields:)
+        assert_valid_attributes!(filters.keys)
+        assert_valid_attributes!(fields)
+
+        id_tree = Assignment.select_descendant_ids([id]).each_with_object({}) do |row, memo|
+          descendant_array = row['descendant_ids'].tr('{}','').split(',')
+          descendant_array.each { |descendant_id| memo[descendant_id] ||= [] }
+          memo[row['id']] = descendant_array
+        end
+
+        id_tree.delete(id.to_s)
+
+        fields_to_pluck = [:id, :unique_identifier] | fields
+        pes = PolicyElement.where(id: id_tree.keys).where(filters).pluck(*fields_to_pluck)
+        fields_except_id = fields_to_pluck - [:id]
+
+        pes.each do |pe|
+          pe_id = pe[0].to_s
+          # Transmute [1, "blue", "user_1"] into { color: "blue", uuid: "user_1" }
+          attribute_hash = HashWithIndifferentAccess[fields_except_id.zip(pe.drop(1))]
+          id_tree[pe_id] = { descendant_ids: id_tree[pe_id] }.merge(attribute_hash)
+        end
+
+        id_tree.each do |pe_id, pe_attrs|
+          if pe_attrs.empty?
+            id_tree.delete(pe_id)
+          else
+            pe_attrs[:descendant_attributes] =
+              pe_attrs[:descendant_ids].map do |descendant_id|
+                if id_tree[descendant_id]
+                  id_tree[descendant_id].except(:descendant_ids)
+                else
+                  {}
+                end
+              end
+            pe_attrs.delete_if { |key,_| [:unique_identifier, :descendant_attributes].exclude?(key) }
+          end
+        end
+
+        id_tree.values
+      end
+
       def self.serialize(store:, name:, serializer: nil)
         active_record_serialize store, serializer
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -63,33 +63,6 @@ module PolicyMachineStorageAdapter
         PolicyElement.where(query, [*element_or_scope].map(&:id))
       end
 
-      # Return an ActiveRecord::Relation containing the ids of all descendants and the
-      # interstitial relationships, as a string of descendant_ids
-      def self.select_descendant_ids(root_element_ids)
-        query = <<-SQL
-          WITH RECURSIVE assignments_recursive AS (
-            (
-              SELECT child_id, parent_id
-              FROM assignments
-              WHERE #{sanitize_sql_for_conditions(["parent_id IN (:root_ids)", root_ids: root_element_ids])}
-            )
-            UNION ALL
-            (
-              SELECT assignments.child_id, assignments.parent_id
-              FROM assignments
-              INNER JOIN assignments_recursive
-              ON assignments_recursive.child_id = assignments.parent_id
-            )
-          )
-
-          SELECT parent_id as id, array_agg(child_id) as descendant_ids
-          FROM assignments_recursive
-          GROUP BY parent_id
-        SQL
-
-        PolicyElement.connection.exec_query(query)
-      end
-
       # Return an ActiveRecord::Relation containing the ids of all ancestors and the
       # interstitial relationships, as a string of ancestor_ids
       def self.select_ancestor_ids(root_element_ids)

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -65,7 +65,7 @@ module PolicyMachineStorageAdapter
 
       # Return an ActiveRecord::Relation containing the ids of all ancestors and the
       # interstitial relationships, as a string of ancestor_ids
-      def self.select_ancestor_ids(root_element_ids)
+      def self.find_ancestor_ids(root_element_ids)
         query = <<-SQL
           WITH RECURSIVE assignments_recursive AS (
             (

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -606,17 +606,52 @@ describe 'ActiveRecord' do
     describe '#pluck_ancestor_attributes_from_ancestors' do
       before { darken_colors.call }
 
+      let(:user_attr_4) { pm1.create_user_attribute('user_attr_4') }
+      let(:user_attr_5) { pm1.create_user_attribute('user_attr_5') }
+      let(:user_attr_6) { pm1.create_user_attribute('user_attr_6') }
+      let!(:single_ancestors) { [user_attr_4, user_attr_5, user_attr_6] }
+
+      let(:user_attr_7) { pm1.create_user_attribute('user_attr_7') }
+      let(:user_attr_8) { pm1.create_user_attribute('user_attr_8') }
+      let(:user_attr_9) { pm1.create_user_attribute('user_attr_9') }
+      let!(:double_ancestors) { [user_attr_7, user_attr_8, user_attr_9] }
+
       context 'no filter is applied' do
-        xit 'returns appropriate ancestors and the specified attribute' do
+        before do
+          single_ancestors.each { |ancestor| ancestor.update(color: 'gold' ) }
+          double_ancestors.each { |ancestor| ancestor.update(color: 'silver' ) }
+          pm1.add_assignment(user_attr_4, user_attr_1)
+          pm1.add_assignment(user_attr_5, user_attr_1)
+          pm1.add_assignment(user_attr_6, user_attr_1)
+
+          pm1.add_assignment(user_attr_7, user_attr_4)
+          pm1.add_assignment(user_attr_8, user_attr_5)
+          pm1.add_assignment(user_attr_9, user_attr_6)
         end
 
-        xit 'returns appropriate ancestors and multiple specified attributes' do
+        it 'returns appropriate ancestors and the specified attribute' do
         end
 
-        xit 'errors appropriately when nonexistent attributes are specified' do
+        it 'returns appropriate ancestors and multiple specified attributes' do
+          plucked_results = {
+            'user_1' => [],
+            'user_2' => [],
+            'user_3' => [],
+            'user_attr_4' => [{ unique_identifier: 'user_attr_7', color: 'silver' }],
+            'user_attr_5' => [{ unique_identifier: 'user_attr_8', color: 'silver' }],
+            'user_attr_6' => [{ unique_identifier: 'user_attr_9', color: 'silver' }],
+            'user_attr_7' => [],
+            'user_attr_8' => [],
+            'user_attr_9' => []
+          }
+          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier, :color]))
+            .to match_array(plucked_results)
         end
 
-        xit 'errors appropriately when no attributes are specified' do
+        it 'errors appropriately when nonexistent attributes are specified' do
+        end
+
+        it 'errors appropriately when no attributes are specified' do
         end
       end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -505,6 +505,51 @@ describe 'ActiveRecord' do
       end
     end
 
+    describe '#pluck_attributes_from_descendants' do
+      before { darken_colors.call }
+
+      context 'no filter is applied' do
+        it 'returns appropriate descendants and the specified attribute' do
+          plucked_results = [{ color: 'green' }, { color: 'forest_green' }, { color: 'green' }]
+          expect(user_1.pluck_attributes_from_descendants(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate descendants and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'user_attr_1', color: 'green' },
+            { unique_identifier: 'user_attr_2', color: 'forest_green' },
+            { unique_identifier: 'user_attr_3', color: 'green' }]
+          expect(user_1.pluck_attributes_from_descendants(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(user_1.pluck_attributes_from_descendants(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(user_1.pluck_attributes_from_descendants(fields: [])) }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'green' }, { color: 'green' }]
+          expect(user_1.pluck_attributes_from_descendants(fields: [:color], filters: { color: 'green' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_attr_1', color: 'green' } }
+          expect(user_1.pluck_attributes_from_descendants(args)).to contain_exactly({ unique_identifier: 'user_attr_1' })
+        end
+
+        it 'returns appropriate results when filters apply to no descendants' do
+          expect(user_1.pluck_attributes_from_descendants(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
+        end
+      end
+    end
+
     describe '#link_descendants' do
       context 'no filter is applied' do
         it 'returns appropriate cross descendants one level deep' do
@@ -599,6 +644,51 @@ describe 'ActiveRecord' do
 
         it 'returns appropriate results when filters apply to no ancestors' do
           expect(user_attr_1.pluck_from_ancestors(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
+        end
+      end
+    end
+
+    describe '#pluck_attributes_from_ancestors' do
+      before { darken_colors.call }
+
+      context 'no filter is applied' do
+        it 'returns appropriate ancestors and the specified attribute' do
+          plucked_results = [{ color: 'blue' }, { color: 'navy_blue' }, { color: 'blue' }]
+          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:color])).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate ancestors and multiple specified attributes' do
+          plucked_results = [
+            { unique_identifier: 'user_1', color: 'blue' },
+            { unique_identifier: 'user_2', color: 'navy_blue' },
+            { unique_identifier: 'user_3', color: 'blue' }]
+          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+        end
+
+        it 'errors appropriately when nonexistent attributes are specified' do
+          expect { expect(user_attr_1.pluck_attributes_from_ancestors(fields: ['favorite_mountain'])) }
+            .to raise_error(ArgumentError)
+        end
+
+        it 'errors appropriately when no attributes are specified' do
+          expect { expect(user_attr_1.pluck_attributes_from_ancestors(fields: [])) }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'a filter is applied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = [{ color: 'blue' }, { color: 'blue' }]
+          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:color], filters: { color: 'blue' }))
+            .to match_array(plucked_results)
+        end
+
+        it 'applies multiple filters if they are supplied' do
+          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_1', color: 'blue' } }
+          expect(user_attr_1.pluck_attributes_from_ancestors(args)).to contain_exactly(unique_identifier: 'user_1')
+        end
+
+        it 'returns appropriate results when filters apply to no ancestors' do
+          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
         end
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -607,12 +607,12 @@ describe 'ActiveRecord' do
       before { darken_colors.call }
 
       context 'no filter is applied' do
-        it 'returns appropriate ancestors and the specified attribute' do
+        xit 'returns appropriate ancestors and the specified attribute' do
           plucked_results = [{ color: 'blue' }, { color: 'navy_blue' }, { color: 'blue' }]
           expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:color])).to match_array(plucked_results)
         end
 
-        it 'returns appropriate ancestors and multiple specified attributes' do
+        xit 'returns appropriate ancestors and multiple specified attributes' do
           plucked_results = [
             { unique_identifier: 'user_1', color: 'blue' },
             { unique_identifier: 'user_2', color: 'navy_blue' },
@@ -620,29 +620,29 @@ describe 'ActiveRecord' do
           expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
 
-        it 'errors appropriately when nonexistent attributes are specified' do
+        xit 'errors appropriately when nonexistent attributes are specified' do
           expect { expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
         end
 
-        it 'errors appropriately when no attributes are specified' do
+        xit 'errors appropriately when no attributes are specified' do
           expect { expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [])) }.to raise_error(ArgumentError)
         end
       end
 
       context 'a filter is applied' do
-        it 'applies a single filter if one is supplied' do
+        xit 'applies a single filter if one is supplied' do
           plucked_results = [{ color: 'blue' }, { color: 'blue' }]
           expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:color], filters: { color: 'blue' }))
             .to match_array(plucked_results)
         end
 
-        it 'applies multiple filters if they are supplied' do
+        xit 'applies multiple filters if they are supplied' do
           args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_1', color: 'blue' } }
           expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(args)).to contain_exactly(unique_identifier: 'user_1')
         end
 
-        it 'returns appropriate results when filters apply to no ancestors' do
+        xit 'returns appropriate results when filters apply to no ancestors' do
           expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
         end
       end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -505,51 +505,6 @@ describe 'ActiveRecord' do
       end
     end
 
-    describe '#pluck_attributes_from_descendants' do
-      before { darken_colors.call }
-
-      context 'no filter is applied' do
-        it 'returns appropriate descendants and the specified attribute' do
-          plucked_results = [{ color: 'green' }, { color: 'forest_green' }, { color: 'green' }]
-          expect(user_1.pluck_attributes_from_descendants(fields: [:color])).to match_array(plucked_results)
-        end
-
-        it 'returns appropriate descendants and multiple specified attributes' do
-          plucked_results = [
-            { unique_identifier: 'user_attr_1', color: 'green' },
-            { unique_identifier: 'user_attr_2', color: 'forest_green' },
-            { unique_identifier: 'user_attr_3', color: 'green' }]
-          expect(user_1.pluck_attributes_from_descendants(fields: [:unique_identifier, :color])).to match_array(plucked_results)
-        end
-
-        it 'errors appropriately when nonexistent attributes are specified' do
-          expect { expect(user_1.pluck_attributes_from_descendants(fields: ['favorite_mountain'])) }
-            .to raise_error(ArgumentError)
-        end
-
-        it 'errors appropriately when no attributes are specified' do
-          expect { expect(user_1.pluck_attributes_from_descendants(fields: [])) }.to raise_error(ArgumentError)
-        end
-      end
-
-      context 'a filter is applied' do
-        it 'applies a single filter if one is supplied' do
-          plucked_results = [{ color: 'green' }, { color: 'green' }]
-          expect(user_1.pluck_attributes_from_descendants(fields: [:color], filters: { color: 'green' }))
-            .to match_array(plucked_results)
-        end
-
-        it 'applies multiple filters if they are supplied' do
-          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_attr_1', color: 'green' } }
-          expect(user_1.pluck_attributes_from_descendants(args)).to contain_exactly({ unique_identifier: 'user_attr_1' })
-        end
-
-        it 'returns appropriate results when filters apply to no descendants' do
-          expect(user_1.pluck_attributes_from_descendants(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
-        end
-      end
-    end
-
     describe '#link_descendants' do
       context 'no filter is applied' do
         it 'returns appropriate cross descendants one level deep' do
@@ -648,7 +603,7 @@ describe 'ActiveRecord' do
       end
     end
 
-    describe '#pluck_attributes_from_ancestors' do
+    describe '#pluck_ancestor_attributes_from_ancestors' do
       before { darken_colors.call }
 
       context 'no filter is applied' do

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -632,34 +632,34 @@ describe 'ActiveRecord' do
 
       context 'no filter is applied' do
         it 'returns appropriate ancestors and the specified attribute' do
-          plucked_results = {
-            'user_1' => [],
-            'user_2' => [],
-            'user_3' => [],
-            'user_attr_4' => [{ unique_identifier: 'user_attr_7' }],
-            'user_attr_5' => [{ unique_identifier: 'user_attr_8' }],
-            'user_attr_6' => [{ unique_identifier: 'user_attr_9' }],
-            'user_attr_7' => [],
-            'user_attr_8' => [],
-            'user_attr_9' => []
-          }
+          plucked_results = HashWithIndifferentAccess.new(
+            user_1: [],
+            user_2: [],
+            user_3: [],
+            user_attr_4: [{ unique_identifier: 'user_attr_7' }],
+            user_attr_5: [{ unique_identifier: 'user_attr_8' }],
+            user_attr_6: [{ unique_identifier: 'user_attr_9' }],
+            user_attr_7: [],
+            user_attr_8: [],
+            user_attr_9: []
+          )
 
-          expect(user_attr_1.pluck_ancestor_tree(fields: [:unique_identifier])).to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_tree(fields: [:unique_identifier])).to eq(plucked_results)
         end
 
         it 'returns appropriate ancestors and multiple specified attributes' do
-          plucked_results = {
-            'user_1' => [],
-            'user_2' => [],
-            'user_3' => [],
-            'user_attr_4' => [{ unique_identifier: 'user_attr_7', color: 'silver' }],
-            'user_attr_5' => [{ unique_identifier: 'user_attr_8', color: 'silver' }],
-            'user_attr_6' => [{ unique_identifier: 'user_attr_9', color: 'silver' }],
-            'user_attr_7' => [],
-            'user_attr_8' => [],
-            'user_attr_9' => []
-          }
-          expect(user_attr_1.pluck_ancestor_tree(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+          plucked_results = HashWithIndifferentAccess.new(
+            user_1: [],
+            user_2: [],
+            user_3: [],
+            user_attr_4: [{ unique_identifier: 'user_attr_7', color: 'silver' }],
+            user_attr_5: [{ unique_identifier: 'user_attr_8', color: 'silver' }],
+            user_attr_6: [{ unique_identifier: 'user_attr_9', color: 'silver' }],
+            user_attr_7: [],
+            user_attr_8: [],
+            user_attr_9: []
+          )
+          expect(user_attr_1.pluck_ancestor_tree(fields: [:unique_identifier, :color])).to eq(plucked_results)
         end
 
         it 'errors appropriately when nonexistent attributes are specified' do
@@ -673,30 +673,30 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
-          plucked_results = { 'user_attr_7' => [], 'user_attr_8' => [], 'user_attr_9' => [] }
+          plucked_results = HashWithIndifferentAccess.new(user_attr_7: [], user_attr_8: [], user_attr_9: [])
           params = { fields: [:unique_identifier], filters: { color: 'silver'} }
-          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
 
         it 'applies multiple filters if they are supplied' do
-          plucked_results = { 'user_attr_9' => [] }
+          plucked_results = HashWithIndifferentAccess.new('user_attr_9': [])
           params = { fields: [:unique_identifier], filters: { color: 'silver', unique_identifier: 'user_attr_9' } }
-          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
 
         it 'returns appropriate results when filters apply to ancestors that have no ancestors themselves' do
           user_attr_10.update(color: 'indigo')
           pm1.add_assignment(user_attr_10, user_attr_1)
 
-          plucked_results = { 'user_attr_10' => [] }
+          plucked_results = HashWithIndifferentAccess.new(user_attr_10: [])
           params = { fields: [:unique_identifier], filters: { color: 'indigo'} }
-          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
 
         it 'returns appropriate results when filters apply to ancestors but not their ancestors' do
-          plucked_results = { 'user_attr_4' => [{}], 'user_attr_5' => [{}], 'user_attr_6' => [{}] }
+          plucked_results = HashWithIndifferentAccess.new(user_attr_4: [], user_attr_5: [], user_attr_6: [])
           params = { fields: [:unique_identifier], filters: { color: 'gold'} }
-          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
 
         it 'returns appropriate results when filters apply to no ancestors' do

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -609,7 +609,7 @@ describe 'ActiveRecord' do
       context 'no filter is applied' do
         it 'returns appropriate ancestors and the specified attribute' do
           plucked_results = [{ color: 'blue' }, { color: 'navy_blue' }, { color: 'blue' }]
-          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:color])).to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:color])).to match_array(plucked_results)
         end
 
         it 'returns appropriate ancestors and multiple specified attributes' do
@@ -617,33 +617,33 @@ describe 'ActiveRecord' do
             { unique_identifier: 'user_1', color: 'blue' },
             { unique_identifier: 'user_2', color: 'navy_blue' },
             { unique_identifier: 'user_3', color: 'blue' }]
-          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:unique_identifier, :color])).to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
 
         it 'errors appropriately when nonexistent attributes are specified' do
-          expect { expect(user_attr_1.pluck_attributes_from_ancestors(fields: ['favorite_mountain'])) }
+          expect { expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: ['favorite_mountain'])) }
             .to raise_error(ArgumentError)
         end
 
         it 'errors appropriately when no attributes are specified' do
-          expect { expect(user_attr_1.pluck_attributes_from_ancestors(fields: [])) }.to raise_error(ArgumentError)
+          expect { expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [])) }.to raise_error(ArgumentError)
         end
       end
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
           plucked_results = [{ color: 'blue' }, { color: 'blue' }]
-          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:color], filters: { color: 'blue' }))
+          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:color], filters: { color: 'blue' }))
             .to match_array(plucked_results)
         end
 
         it 'applies multiple filters if they are supplied' do
           args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_1', color: 'blue' } }
-          expect(user_attr_1.pluck_attributes_from_ancestors(args)).to contain_exactly(unique_identifier: 'user_1')
+          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(args)).to contain_exactly(unique_identifier: 'user_1')
         end
 
         it 'returns appropriate results when filters apply to no ancestors' do
-          expect(user_attr_1.pluck_attributes_from_ancestors(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
+          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
         end
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -608,42 +608,26 @@ describe 'ActiveRecord' do
 
       context 'no filter is applied' do
         xit 'returns appropriate ancestors and the specified attribute' do
-          plucked_results = [{ color: 'blue' }, { color: 'navy_blue' }, { color: 'blue' }]
-          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:color])).to match_array(plucked_results)
         end
 
         xit 'returns appropriate ancestors and multiple specified attributes' do
-          plucked_results = [
-            { unique_identifier: 'user_1', color: 'blue' },
-            { unique_identifier: 'user_2', color: 'navy_blue' },
-            { unique_identifier: 'user_3', color: 'blue' }]
-          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
 
         xit 'errors appropriately when nonexistent attributes are specified' do
-          expect { expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: ['favorite_mountain'])) }
-            .to raise_error(ArgumentError)
         end
 
         xit 'errors appropriately when no attributes are specified' do
-          expect { expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [])) }.to raise_error(ArgumentError)
         end
       end
 
       context 'a filter is applied' do
         xit 'applies a single filter if one is supplied' do
-          plucked_results = [{ color: 'blue' }, { color: 'blue' }]
-          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:color], filters: { color: 'blue' }))
-            .to match_array(plucked_results)
         end
 
         xit 'applies multiple filters if they are supplied' do
-          args = { fields: [:unique_identifier], filters: { unique_identifier: 'user_1', color: 'blue' } }
-          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(args)).to contain_exactly(unique_identifier: 'user_1')
         end
 
         xit 'returns appropriate results when filters apply to no ancestors' do
-          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier], filters: { color: 'red' })).to be_empty
         end
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -603,9 +603,7 @@ describe 'ActiveRecord' do
       end
     end
 
-    describe '#pluck_ancestor_attributes_from_ancestors' do
-      before { darken_colors.call }
-
+    describe '#pluck_ancestor_tree' do
       let(:user_attr_4) { pm1.create_user_attribute('user_attr_4') }
       let(:user_attr_5) { pm1.create_user_attribute('user_attr_5') }
       let(:user_attr_6) { pm1.create_user_attribute('user_attr_6') }
@@ -616,20 +614,37 @@ describe 'ActiveRecord' do
       let(:user_attr_9) { pm1.create_user_attribute('user_attr_9') }
       let!(:double_ancestors) { [user_attr_7, user_attr_8, user_attr_9] }
 
+      let(:user_attr_10) { pm1.create_user_attribute('user_attr_10') }
+
+      before do
+        darken_colors.call
+
+        single_ancestors.each { |ancestor| ancestor.update(color: 'gold' ) }
+        double_ancestors.each { |ancestor| ancestor.update(color: 'silver' ) }
+        pm1.add_assignment(user_attr_4, user_attr_1)
+        pm1.add_assignment(user_attr_5, user_attr_1)
+        pm1.add_assignment(user_attr_6, user_attr_1)
+
+        pm1.add_assignment(user_attr_7, user_attr_4)
+        pm1.add_assignment(user_attr_8, user_attr_5)
+        pm1.add_assignment(user_attr_9, user_attr_6)
+      end
+
       context 'no filter is applied' do
-        before do
-          single_ancestors.each { |ancestor| ancestor.update(color: 'gold' ) }
-          double_ancestors.each { |ancestor| ancestor.update(color: 'silver' ) }
-          pm1.add_assignment(user_attr_4, user_attr_1)
-          pm1.add_assignment(user_attr_5, user_attr_1)
-          pm1.add_assignment(user_attr_6, user_attr_1)
-
-          pm1.add_assignment(user_attr_7, user_attr_4)
-          pm1.add_assignment(user_attr_8, user_attr_5)
-          pm1.add_assignment(user_attr_9, user_attr_6)
-        end
-
         it 'returns appropriate ancestors and the specified attribute' do
+          plucked_results = {
+            'user_1' => [],
+            'user_2' => [],
+            'user_3' => [],
+            'user_attr_4' => [{ unique_identifier: 'user_attr_7' }],
+            'user_attr_5' => [{ unique_identifier: 'user_attr_8' }],
+            'user_attr_6' => [{ unique_identifier: 'user_attr_9' }],
+            'user_attr_7' => [],
+            'user_attr_8' => [],
+            'user_attr_9' => []
+          }
+
+          expect(user_attr_1.pluck_ancestor_tree(fields: [:unique_identifier])).to match_array(plucked_results)
         end
 
         it 'returns appropriate ancestors and multiple specified attributes' do
@@ -644,25 +659,49 @@ describe 'ActiveRecord' do
             'user_attr_8' => [],
             'user_attr_9' => []
           }
-          expect(user_attr_1.pluck_ancestor_attributes_from_ancestors(fields: [:unique_identifier, :color]))
-            .to match_array(plucked_results)
+          expect(user_attr_1.pluck_ancestor_tree(fields: [:unique_identifier, :color])).to match_array(plucked_results)
         end
 
         it 'errors appropriately when nonexistent attributes are specified' do
+          expect { user_attr_1.pluck_ancestor_tree(fields: [:dog]) }.to raise_error(ArgumentError)
         end
 
         it 'errors appropriately when no attributes are specified' do
+          expect { user_attr_1.pluck_ancestor_tree(fields: []) }.to raise_error(ArgumentError)
         end
       end
 
       context 'a filter is applied' do
-        xit 'applies a single filter if one is supplied' do
+        it 'applies a single filter if one is supplied' do
+          plucked_results = { 'user_attr_7' => [], 'user_attr_8' => [], 'user_attr_9' => [] }
+          params = { fields: [:unique_identifier], filters: { color: 'silver'} }
+          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
         end
 
-        xit 'applies multiple filters if they are supplied' do
+        it 'applies multiple filters if they are supplied' do
+          plucked_results = { 'user_attr_9' => [] }
+          params = { fields: [:unique_identifier], filters: { color: 'silver', unique_identifier: 'user_attr_9' } }
+          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
         end
 
-        xit 'returns appropriate results when filters apply to no ancestors' do
+        it 'returns appropriate results when filters apply to ancestors that have no ancestors themselves' do
+          user_attr_10.update(color: 'indigo')
+          pm1.add_assignment(user_attr_10, user_attr_1)
+
+          plucked_results = { 'user_attr_10' => [] }
+          params = { fields: [:unique_identifier], filters: { color: 'indigo'} }
+          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate results when filters apply to ancestors but not their ancestors' do
+          plucked_results = { 'user_attr_4' => [{}], 'user_attr_5' => [{}], 'user_attr_6' => [{}] }
+          params = { fields: [:unique_identifier], filters: { color: 'gold'} }
+          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array(plucked_results)
+        end
+
+        it 'returns appropriate results when filters apply to no ancestors' do
+          params = { fields: [:unique_identifier], filters: { color: 'obsidian'} }
+          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array({})
         end
       end
     end


### PR DESCRIPTION
The goal is to, from a root node, pluck all the attributes from ancestors of ancestors. This is to bypass the memory overhead of instantiating ancestor objects to determine inherited attributes, and remove the n+1 problem inherent in `pluck`ing from each ancestor in turn.

This will be PM version 1.7.0.