### PR TITLE
Add root node to pluck_ancestor_tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.1
+* Added root node to pluck_ancestor_tree method with parent relationships identified.
+
 ## 1.7.0
 * Add pluck_ancestor_tree method to ActiveRecord storage adapter.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -216,10 +216,11 @@ module PolicyMachineStorageAdapter
         assert_valid_attributes!(fields)
 
         id_tree = get_ancestor_id_tree([id])
-        id_tree.delete(id.to_s)
 
         fields_to_pluck = [:id, :unique_identifier] | fields
-        plucked_policy_elements = PolicyElement.where(id: id_tree.keys).where(filters).pluck(*fields_to_pluck)
+        ancestor_attributes = PolicyElement.where(id: id_tree.keys - [id.to_s]).where(filters).pluck(*fields_to_pluck)
+        root_attributes     = PolicyElement.where(id: id.to_s).pluck(:id, :unique_identifier)
+        plucked_policy_elements = ancestor_attributes + root_attributes
 
         # Convert the plucked attribute arrays into attribute hashes and merge them into the id subtree
         id_attribute_tree = zip_attributes_into_id_tree(id_tree, fields_to_pluck - [:id], plucked_policy_elements)

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -633,6 +633,13 @@ describe 'ActiveRecord' do
       context 'no filter is applied' do
         it 'returns appropriate ancestors and the specified attribute' do
           plucked_results = HashWithIndifferentAccess.new(
+            user_attr_1: [
+              { unique_identifier: 'user_1' },
+              { unique_identifier: 'user_2' },
+              { unique_identifier: 'user_3' },
+              { unique_identifier: 'user_attr_4' },
+              { unique_identifier: 'user_attr_5' },
+              { unique_identifier: 'user_attr_6' }],
             user_1: [],
             user_2: [],
             user_3: [],
@@ -649,6 +656,13 @@ describe 'ActiveRecord' do
 
         it 'returns appropriate ancestors and multiple specified attributes' do
           plucked_results = HashWithIndifferentAccess.new(
+            user_attr_1: [
+              { unique_identifier: 'user_1', color: 'blue' },
+              { unique_identifier: 'user_2', color: 'navy_blue' },
+              { unique_identifier: 'user_3', color: 'blue' },
+              { unique_identifier: 'user_attr_4', color: 'gold' },
+              { unique_identifier: 'user_attr_5', color: 'gold' },
+              { unique_identifier: 'user_attr_6', color: 'gold' }],
             user_1: [],
             user_2: [],
             user_3: [],
@@ -673,13 +687,21 @@ describe 'ActiveRecord' do
 
       context 'a filter is applied' do
         it 'applies a single filter if one is supplied' do
-          plucked_results = HashWithIndifferentAccess.new(user_attr_7: [], user_attr_8: [], user_attr_9: [])
+          plucked_results = HashWithIndifferentAccess.new(
+            user_attr_1: [],
+            user_attr_7: [],
+            user_attr_8: [],
+            user_attr_9: []
+          )
           params = { fields: [:unique_identifier], filters: { color: 'silver'} }
           expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
 
         it 'applies multiple filters if they are supplied' do
-          plucked_results = HashWithIndifferentAccess.new('user_attr_9': [])
+          plucked_results = HashWithIndifferentAccess.new(
+            user_attr_1: [],
+            user_attr_9: []
+          )
           params = { fields: [:unique_identifier], filters: { color: 'silver', unique_identifier: 'user_attr_9' } }
           expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
@@ -688,20 +710,32 @@ describe 'ActiveRecord' do
           user_attr_10.update(color: 'indigo')
           pm1.add_assignment(user_attr_10, user_attr_1)
 
-          plucked_results = HashWithIndifferentAccess.new(user_attr_10: [])
+          plucked_results = HashWithIndifferentAccess.new(
+            user_attr_1: [{ unique_identifier: 'user_attr_10' }],
+            user_attr_10: []
+          )
           params = { fields: [:unique_identifier], filters: { color: 'indigo'} }
           expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
 
         it 'returns appropriate results when filters apply to ancestors but not their ancestors' do
-          plucked_results = HashWithIndifferentAccess.new(user_attr_4: [], user_attr_5: [], user_attr_6: [])
+          plucked_results = HashWithIndifferentAccess.new(
+            user_attr_1: [
+              { unique_identifier: 'user_attr_4' },
+              { unique_identifier: 'user_attr_5' },
+              { unique_identifier: 'user_attr_6' }],
+            user_attr_4: [],
+            user_attr_5: [],
+            user_attr_6: []
+          )
           params = { fields: [:unique_identifier], filters: { color: 'gold'} }
           expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
 
         it 'returns appropriate results when filters apply to no ancestors' do
+          plucked_results = HashWithIndifferentAccess.new(user_attr_1: [])
           params = { fields: [:unique_identifier], filters: { color: 'obsidian'} }
-          expect(user_attr_1.pluck_ancestor_tree(params)).to match_array({})
+          expect(user_attr_1.pluck_ancestor_tree(params)).to eq(plucked_results)
         end
       end
     end


### PR DESCRIPTION
This PR adds the root node to the `pluck_ancestor_tree` method in the ActiveRecord storage adapter. It was previously excluded due to the optional filters, which may not (and should not) apply to the root. However, this 'first step' relationship is important downstream.