### PR TITLE
[MCC-361558] Add accessible_ancestor_objects to ActiveRecord storage adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ## 1.7.1
 * Downversion 'pg' gem to '~> 0.15.0' to avoid v1.0.0 error with core Rails.
 
-## 1.7.0
+## 1.7.0 
 * Add pluck_ancestor_tree method to ActiveRecord storage adapter.
 
 ## 1.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.0
+* Add accessible_ancestor_objects method to ActiveRecord storage adapter.
+
 ## 1.7.0
 * Add pluck_ancestor_tree method to ActiveRecord storage adapter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ## 1.7.1
 * Downversion 'pg' gem to '~> 0.15.0' to avoid v1.0.0 error with core Rails.
 
-## 1.7.0 
+## 1.7.0
 * Add pluck_ancestor_tree method to ActiveRecord storage adapter.
 
 ## 1.6.2

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -271,9 +271,8 @@ class PolicyMachine
     if policy_machine_storage_adapter.respond_to?(:accessible_ancestor_objects)
       policy_machine_storage_adapter.accessible_ancestor_objects(user_or_attribute, operation, root_object, options)
     else
-      Warn.once "WARNING: accessible_ancestor_objects is not implemented for storage adapter " \
-                "#{policy_machine_storage_adapter.class}. Returning all accessible_objects."
-      accessible_objects(user_or_attribute, operation, options)
+      raise NoMethodError, "accessible_ancestor_objects is not implemented for storage adapter " \
+                           "#{policy_machine_storage_adapter.class}."
     end
   end
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -267,6 +267,16 @@ class PolicyMachine
     end
   end
 
+  def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
+    if policy_machine_storage_adapter.respond_to?(:accessible_ancestor_objects)
+      policy_machine_storage_adapter.accessible_ancestor_objects(user_or_attribute, operation, root_object, options)
+    else
+      Warn.once "WARNING: accessible_ancestor_objects is not implemented for storage adapter " \
+                "#{policy_machine_storage_adapter.class}. Returning all accessible_objects."
+      accessible_objects(user_or_attribute, operation, options)
+    end
+  end
+
   ##
   # Returns an array of all user_attributes a PM::User is assigned to,
   # directly or indirectly.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.7.4"
+  VERSION = "1.8.0"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -807,7 +807,7 @@ module PolicyMachineStorageAdapter
 
       # Short-circuit and return all ancestors (minus prohibitions), if authorized on the root node
       if is_privilege?(user_or_attribute, operation, root_object_pe)
-        if options[:ignore_prohibitions]
+        if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation))
           if inclusion = options[:includes]
             return ancestor_objects.select { |obj| obj.send(options[:key].to_sym).include?(inclusion) }
           else
@@ -837,9 +837,6 @@ module PolicyMachineStorageAdapter
           filtered_operation_set_ids.include?(association.operation_set_id)
         end
 
-      # TODO: Add a filter here to limit the list of permitting OAs to the set of ancestor objects
-      # Complication: an object may be accessible from ancestors not in the set
-      # i.e. how interconnected are subgraphs?
       permitting_oa_ids = filtered_associations.map(&:object_attribute_id)
       permitting_oas = PolicyElement.where(id: permitting_oa_ids)
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -821,7 +821,7 @@ module PolicyMachineStorageAdapter
         indirect_scope = Adapter.apply_include_condition(scope: indirect_scope, key: options[:key], value: inclusion, klass: class_for_type('object'))
       end
 
-      candidates = direct_scope | indirect_scope
+      candidates = (direct_scope | indirect_scope) | root_object.descendants
 
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation_id))
         candidates

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -799,8 +799,11 @@ module PolicyMachineStorageAdapter
     # Version of accessible_objects which only returns objects that are
     # ancestors of a specified root object or the object itself
     def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
+      # Drop down to the root's stored policy element if not already there
+      root_object = root_object.respond_to?(:stored_pe) ? root_object.stored_pe : root_object
+
       # The final set of accessible objects must be contained in the following set
-      ancestor_objects = root_object.ancestors(type: class_for_type('object')) + [root_object.stored_pe]
+      ancestor_objects = root_object.ancestors(type: class_for_type('object')) + [root_object]
 
       # Short-circuit and return all ancestors (minus prohibitions), if authorized on the root node
       if is_privilege?(user_or_attribute, operation, root_object)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -1011,9 +1011,9 @@ module PolicyMachineStorageAdapter
           root_object,
           options.merge(ignore_prohibitions: true)
         )
-        return ancestor_objects - prohibited_ancestor_objects
+        ancestor_objects - prohibited_ancestor_objects
       else
-        return ancestor_objects
+        ancestor_objects
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -779,7 +779,8 @@ module PolicyMachineStorageAdapter
       root_object_stored_pe = root_object.try(:stored_pe) || root_object
 
       # The final set of accessible objects must be ancestors of the root_object
-      ancestor_objects = root_object_stored_pe.ancestors(type: class_for_type('object')) + [root_object_stored_pe]
+      ancestor_objects = options[:ancestor_objects]
+      ancestor_objects ||= root_object_stored_pe.ancestors(type: class_for_type('object')) + [root_object_stored_pe]
 
       # Short-circuit and return all ancestors (minus prohibitions) if the user_or_attribute
       # is authorized on the root node
@@ -818,7 +819,8 @@ module PolicyMachineStorageAdapter
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation_id))
         candidates
       else
-        candidates - accessible_ancestor_objects(user_or_attribute, prohibition, root_object, options.merge(ignore_prohibitions: true))
+        preloaded_options = options.merge(ignore_prohibitions: true, ancestor_objects: ancestor_objects)
+        candidates - accessible_ancestor_objects(user_or_attribute, prohibition, root_object, preloaded_options)
       end
     end
 
@@ -1009,7 +1011,7 @@ module PolicyMachineStorageAdapter
           user_or_attribute,
           prohibition,
           root_object,
-          options.merge(ignore_prohibitions: true)
+          options.merge(ignore_prohibitions: true, ancestor_objects: ancestor_objects)
         )
         ancestor_objects - prohibited_ancestor_objects
       else

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -814,7 +814,7 @@ module PolicyMachineStorageAdapter
             return ancestor_objects
           end
         else
-          ancestor_objects_minus_prohibitions = ancestor_objects - accessible_ancestor_objects(user_or_attribute, prohibition_for(operation), root_object)
+          ancestor_objects_minus_prohibitions = ancestor_objects - accessible_ancestor_objects(user_or_attribute, prohibition_for(operation), root_object_pe)
 
           if inclusion = options[:includes]
             return ancestor_objects_minus_prohibitions.select { |obj| obj.send(options[:key].to_sym).include?(inclusion) }

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -797,7 +797,7 @@ module PolicyMachineStorageAdapter
     end
 
     # Version of accessible_objects which only returns objects that are
-    # ancestors of a specified root object or the object itself.
+    # ancestors of a specified root object or the object itself
     def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
       # The final set of accessible objects must be contained in the following set
       ancestor_objects = root_object.ancestors(type: class_for_type('object')) + [root_object.stored_pe]

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -701,14 +701,14 @@ module PolicyMachineStorageAdapter
     # Return array of all policy classes which contain the given object_attribute (or object).
     # Return empty array if no such policy classes found.
     def policy_classes_for_object_attribute(object_attribute)
-      object_attribute.descendants.merge(PolicyElement.where(type: class_for_type('policy_class')))
+      object_attribute.descendants.to_set.add(PolicyElement.where(type: class_for_type('policy_class'))).to_a
     end
 
     ##
     # Return array of all user attributes which contain the given user.
     # Return empty array if no such user attributes are found.
     def user_attributes_for_user(user)
-      user.descendants.merge(PolicyElement.where(type: class_for_type('user_attribute')))
+      user.descendants.to_set.add(PolicyElement.where(type: class_for_type('user_attribute'))).to_a
     end
 
     ##

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -800,13 +800,13 @@ module PolicyMachineStorageAdapter
     # ancestors of a specified root object or the object itself
     def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
       # Drop down to the root's stored policy element if not already there
-      root_object = root_object.respond_to?(:stored_pe) ? root_object.stored_pe : root_object
+      root_object_pe = root_object.respond_to?(:stored_pe) ? root_object.stored_pe : root_object
 
       # The final set of accessible objects must be contained in the following set
-      ancestor_objects = root_object.ancestors(type: class_for_type('object')) + [root_object]
+      ancestor_objects = root_object_pe.ancestors(type: class_for_type('object')) + [root_object_pe]
 
       # Short-circuit and return all ancestors (minus prohibitions), if authorized on the root node
-      if is_privilege?(user_or_attribute, operation, root_object)
+      if is_privilege?(user_or_attribute, operation, root_object_pe)
         if options[:ignore_prohibitions]
           if inclusion = options[:includes]
             return ancestor_objects.select { |obj| obj.send(options[:key].to_sym).include?(inclusion) }

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -701,14 +701,14 @@ module PolicyMachineStorageAdapter
     # Return array of all policy classes which contain the given object_attribute (or object).
     # Return empty array if no such policy classes found.
     def policy_classes_for_object_attribute(object_attribute)
-      object_attribute.descendants.to_set.add(PolicyElement.where(type: class_for_type('policy_class'))).to_a
+      object_attribute.descendants.merge(PolicyElement.where(type: class_for_type('policy_class')))
     end
 
     ##
     # Return array of all user attributes which contain the given user.
     # Return empty array if no such user attributes are found.
     def user_attributes_for_user(user)
-      user.descendants.to_set.add(PolicyElement.where(type: class_for_type('user_attribute'))).to_a
+      user.descendants.merge(PolicyElement.where(type: class_for_type('user_attribute')))
     end
 
     ##

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -778,7 +778,8 @@ module PolicyMachineStorageAdapter
       # If the root_object is a generic PM::Object, convert it the appropriate storage adapter Object
       root_object_stored_pe = root_object.try(:stored_pe) || root_object
 
-      # The final set of accessible objects must be ancestors of the root_object
+      # The final set of accessible objects must be ancestors of the root_object; avoid
+      # duplicate ancestor calls when possible
       ancestor_objects = options[:ancestor_objects]
       ancestor_objects ||= root_object_stored_pe.ancestors(type: class_for_type('object')) + [root_object_stored_pe]
 
@@ -1003,6 +1004,8 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    # Filter all ancestor objects from a common root by the provided include condition
+    # and/or pre-existing prohibitions
     def all_ancestor_objects(user_or_attribute, operation, root_object, ancestor_objects, options)
       apply_include_condition!(ancestor_objects, options[:key], options[:includes])
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -803,10 +803,7 @@ module PolicyMachineStorageAdapter
       # Narrow the list of PEAs to just those containing the specified operation
       operation_id = operation.try(:unique_identifier) || operation.to_s
       filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
-      filtered_associations =
-        associations.select do |association|
-          filtered_operation_set_ids.include?(association.operation_set_id)
-        end
+      filtered_associations = associations.where(operation_set_id: filtered_operation_set_ids)
 
       permitting_oa_ids = filtered_associations.map(&:object_attribute_id)
       permitting_oas = PolicyElement.where(id: permitting_oa_ids)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -796,6 +796,40 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    # Version of accessible_objects which only returns objects that are
+    # descendants of a specified root object.
+    def accessible_descendant_objects(user_or_attribute, operation, root_object, options = {})
+      operation_id = operation.try(:unique_identifier) || operation.to_s
+
+      user_attributes = user_or_attribute.descendants | [user_or_attribute]
+      associations = PolicyElementAssociation.where(user_attribute_id: user_attributes.map(&:id))
+      operation_set_ids = associations.pluck(:operation_set_id)
+
+      filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
+      filtered_associations =
+        associations.select do |association|
+          filtered_operation_set_ids.include?(association.operation_set_id)
+        end
+
+      permitting_oas = PolicyElement.where(id: filtered_associations.map(&:object_attribute_id))
+
+      direct_scope = permitting_oas.where(type: class_for_type('object'))
+      indirect_scope = Assignment.ancestors_of(permitting_oas).where(type: class_for_type('object'))
+
+      if inclusion = options[:includes]
+        direct_scope = Adapter.apply_include_condition(scope: direct_scope, key: options[:key], value: inclusion, klass: class_for_type('object'))
+        indirect_scope = Adapter.apply_include_condition(scope: indirect_scope, key: options[:key], value: inclusion, klass: class_for_type('object'))
+      end
+
+      candidates = direct_scope | indirect_scope
+
+      if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation_id))
+        candidates
+      else
+        candidates - accessible_objects(user_or_attribute, prohibition, options.merge(ignore_prohibitions: true))
+      end
+    end
+
     private
 
     def prohibition_for(operation)

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -341,13 +341,13 @@ describe 'ActiveRecord' do
       before do
         n = 20
         @pm = PolicyMachine.new(:name => 'ActiveRecord PM', :storage_adapter => PolicyMachineStorageAdapter::ActiveRecord)
-        u1 = @pm.create_user('u1')
+        @u1 = @pm.create_user('u1')
         @op = @pm.create_operation('own')
         @op_set = @pm.create_operation_set('owner')
         @user_attributes = (1..n).map { |i| @pm.create_user_attribute("ua#{i}") }
         @object_attributes = (1..n).map { |i| @pm.create_object_attribute("oa#{i}") }
         @objects = (1..n).map { |i| @pm.create_object("o#{i}") }
-        @user_attributes.each { |ua| @pm.add_assignment(u1, ua) }
+        @user_attributes.each { |ua| @pm.add_assignment(@u1, ua) }
         @pm.add_assignment(@op_set, @op)
         @object_attributes.product(@user_attributes) { |oa, ua| @pm.add_association(ua, @op_set, oa) }
         @object_attributes.zip(@objects) { |oa, o| @pm.add_assignment(o, oa) }
@@ -356,13 +356,14 @@ describe 'ActiveRecord' do
       it 'does not have O(n) database calls' do
         #TODO: Find a way to count all database calls that doesn't conflict with ActiveRecord magic
         expect(PolicyMachineStorageAdapter::ActiveRecord::Assignment).to receive(:transitive_closure?).at_most(10).times
-        expect(@pm.is_privilege?(u1, @op, @objects.first)).to be true
+        expect(@pm.is_privilege?(@u1, @op, @objects.first)).to be true
       end
     end
   end
 
   describe '#accessible_descendant_objects' do
-    let(:ado_pm) { PolicyMachine.new(name: 'ActiveRecord PM', storage_adapter: PolicyMachineStorageAdapter::ActiveRecord) }
+    let(:ado_pm) { PolicyMachine.new(name: 'ADO ActiveRecord PM', storage_adapter: PolicyMachineStorageAdapter::ActiveRecord) }
+    let(:adapt) { ado_pm.policy_machine_storage_adapter}
 
     let!(:one_fish) { ado_pm.create_object('one:fish') }
     let!(:two_fish) { ado_pm.create_object('two:fish') }
@@ -386,13 +387,13 @@ describe 'ActiveRecord' do
     end
 
     it 'lists all objects with the given privilege for the given user' do
-      expect(ado_pm.accessible_descendant_objects(u1, read, 0, key: :unique_identifier).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
-      expect(ado_pm.accessible_descendant_objects(u1, write, 0, key: :unique_identifier).map(&:unique_identifier) ).to eq( ['red:one'] )
+      expect(adapt.accessible_descendant_objects(u1, read, 0, key: :unique_identifier).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
+      expect(adapt.accessible_descendant_objects(u1, write, 0, key: :unique_identifier).map(&:unique_identifier) ).to eq( ['red:one'] )
     end
 
     it 'filters objects via substring matching' do
-      expect(ado_pm.accessible_descendant_objects(u1, read, 0, includes: 'fish', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['one:fish','two:fish'])
-      expect(ado_pm.accessible_descendant_objects(u1, read, 0, includes: 'one', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['one:fish','red:one'])
+      expect(adapt.accessible_descendant_objects(u1, read, 0, includes: 'fish', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['one:fish','two:fish'])
+      expect(adapt.accessible_descendant_objects(u1, read, 0, includes: 'one', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['one:fish','red:one'])
     end
 
     context 'cascading operation sets' do
@@ -409,11 +410,11 @@ describe 'ActiveRecord' do
       end
 
       it 'lists all objects with the given privilege for the given user 1 operation set deep' do
-        expect(ado_pm.accessible_descendant_objects(u1, speed_read, 0, key: :unique_identifier).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
+        expect(adapt.accessible_descendant_objects(u1, speed_read, 0, key: :unique_identifier).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
       end
 
       it 'lists all objects with the given privilege for the given user 2 operation sets deep' do
-        expect(ado_pm.accessible_descendant_objects(u1, speediest_read, 0, key: :unique_identifier).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
+        expect(adapt.accessible_descendant_objects(u1, speediest_read, 0, key: :unique_identifier).map(&:unique_identifier) ).to include('one:fish','two:fish','red:one')
       end
     end
   end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -412,7 +412,7 @@ describe 'ActiveRecord' do
     it 'lists all objects with the given privilege provided by an out-of-scope descendant' do
       wrestle = ado_pm.create_operation('wrestle')
       wrestler = ado_pm.create_operation_set('wrestler')
-      ado_pm.add_assignment(wrestler, wrestle)
+      ado_pm.add_assignment(wrestler, wrestle) 
 
       # Give the user 'wrestle' on the highest, out-of-scope node
       ado_pm.add_association(ua, wrestler, grandparent_fish)

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -363,7 +363,6 @@ describe 'ActiveRecord' do
 
   describe '#accessible_ancestor_objects' do
     let(:ado_pm) { PolicyMachine.new(name: 'ADO ActiveRecord PM', storage_adapter: PolicyMachineStorageAdapter::ActiveRecord) }
-    let(:adapt) { ado_pm.policy_machine_storage_adapter}
 
     let!(:grandparent_fish) { ado_pm.create_object('grandparent_fish') }
     let!(:parent_fish) { ado_pm.create_object('parent_fish') }
@@ -403,9 +402,9 @@ describe 'ActiveRecord' do
     it 'lists all objects with the given privilege for the given user that are ancestors of a specified object' do
       all_accessible_from_grandparent = %w(grandparent_fish parent_fish uncle_fish cousin_fish child_fish_1 child_fish_2)
 
-      expect(adapt.accessible_ancestor_objects(u1, read, grandparent_fish, key: :unique_identifier).map(&:unique_identifier))
+      expect(ado_pm.accessible_ancestor_objects(u1, read, grandparent_fish, key: :unique_identifier).map(&:unique_identifier))
         .to match_array(all_accessible_from_grandparent)
-      expect(adapt.accessible_ancestor_objects(u1, write, parent_fish, key: :unique_identifier).map(&:unique_identifier))
+      expect(ado_pm.accessible_ancestor_objects(u1, write, parent_fish, key: :unique_identifier).map(&:unique_identifier))
         .to contain_exactly('child_fish_1')
     end
 
@@ -419,12 +418,12 @@ describe 'ActiveRecord' do
 
       all_accessible_from_parent = %w(parent_fish child_fish_1 child_fish_2)
 
-      expect(adapt.accessible_ancestor_objects(u1, wrestle, parent_fish, key: :unique_identifier).map(&:unique_identifier))
+      expect(ado_pm.accessible_ancestor_objects(u1, wrestle, parent_fish, key: :unique_identifier).map(&:unique_identifier))
         .to match_array(all_accessible_from_parent)
     end
 
     it 'does not return objects which are not ancestors of the specified object' do
-      all_accessible_from_uncle = adapt.accessible_ancestor_objects(u1, read, uncle_fish, key: :unique_identifier)
+      all_accessible_from_uncle = ado_pm.accessible_ancestor_objects(u1, read, uncle_fish, key: :unique_identifier)
 
       expect(all_accessible_from_uncle.map(&:unique_identifier)).to contain_exactly('uncle_fish', 'cousin_fish')
     end
@@ -438,8 +437,8 @@ describe 'ActiveRecord' do
       ado_pm.add_association(ua, bluffer, cousin_fish)
       ado_pm.add_association(ua, bluffer, child_fish_1)
 
-      all_accessible_from_grandparent = adapt.accessible_ancestor_objects(u1, bluff, grandparent_fish, key: :unique_identifier)
-      all_accessible_from_parent = adapt.accessible_ancestor_objects(u1, bluff, parent_fish, key: :unique_identifier)
+      all_accessible_from_grandparent = ado_pm.accessible_ancestor_objects(u1, bluff, grandparent_fish, key: :unique_identifier)
+      all_accessible_from_parent = ado_pm.accessible_ancestor_objects(u1, bluff, parent_fish, key: :unique_identifier)
 
       # Verify 'bluff' is still visible when not present on intermediate nodes, namely 'uncle' and 'parent'
       expect(all_accessible_from_grandparent.map(&:unique_identifier)).to contain_exactly('child_fish_1', 'cousin_fish')
@@ -447,9 +446,9 @@ describe 'ActiveRecord' do
     end
 
     it 'filters objects via substring matching' do
-      expect(adapt.accessible_ancestor_objects(u1, read, grandparent_fish, includes: 'parent', key: :unique_identifier).map(&:unique_identifier))
+      expect(ado_pm.accessible_ancestor_objects(u1, read, grandparent_fish, includes: 'parent', key: :unique_identifier).map(&:unique_identifier))
         .to contain_exactly('grandparent_fish', 'parent_fish')
-      expect(adapt.accessible_ancestor_objects(u1, read, grandparent_fish, includes: 'messedupstring', key: :unique_identifier).map(&:unique_identifier))
+      expect(ado_pm.accessible_ancestor_objects(u1, read, grandparent_fish, includes: 'messedupstring', key: :unique_identifier).map(&:unique_identifier))
         .to be_empty
     end
 
@@ -467,12 +466,12 @@ describe 'ActiveRecord' do
       end
 
       it 'lists all objects with the given privilege for the given user 1 operation set deep' do
-        expect(adapt.accessible_ancestor_objects(u1, speed_write, parent_fish, key: :unique_identifier).map(&:unique_identifier))
+        expect(ado_pm.accessible_ancestor_objects(u1, speed_write, parent_fish, key: :unique_identifier).map(&:unique_identifier))
           .to contain_exactly('child_fish_1')
       end
 
       it 'lists all objects with the given privilege for the given user 2 operation sets deep' do
-        expect(adapt.accessible_ancestor_objects(u1, speediest_write, grandparent_fish, key: :unique_identifier).map(&:unique_identifier))
+        expect(ado_pm.accessible_ancestor_objects(u1, speediest_write, grandparent_fish, key: :unique_identifier).map(&:unique_identifier))
           .to contain_exactly('child_fish_1')
       end
     end
@@ -488,16 +487,16 @@ describe 'ActiveRecord' do
         ado_pm.add_association(ua, not_reader, parent_fish)
         all_accessible_from_grandparent = %w(grandparent_fish uncle_fish cousin_fish)
 
-        expect(adapt.accessible_ancestor_objects(u1, read, grandparent_fish, key: :unique_identifier).map(&:unique_identifier))
+        expect(ado_pm.accessible_ancestor_objects(u1, read, grandparent_fish, key: :unique_identifier).map(&:unique_identifier))
           .to match_array(all_accessible_from_grandparent)
-        expect(adapt.accessible_ancestor_objects(u1, write, parent_fish, key: :unique_identifier).map(&:unique_identifier))
+        expect(ado_pm.accessible_ancestor_objects(u1, write, parent_fish, key: :unique_identifier).map(&:unique_identifier))
           .to contain_exactly('child_fish_1')
       end
 
       it 'does not return objects which prohibited by an out-of-scope descendant' do
         ado_pm.add_association(ua, not_reader, grandparent_fish)
 
-        expect(adapt.accessible_ancestor_objects(u1, read, parent_fish, key: :unique_identifier).map(&:unique_identifier))
+        expect(ado_pm.accessible_ancestor_objects(u1, read, parent_fish, key: :unique_identifier).map(&:unique_identifier))
           .to be_empty
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -539,7 +539,7 @@ describe 'ActiveRecord' do
           .to contain_exactly('child_fish_1')
       end
 
-      it 'does not return objects which prohibited by an out-of-scope descendant' do
+      it 'does not return objects which are prohibited by an out-of-scope descendant' do
         ado_pm.add_association(ua, not_reader, grandparent_fish)
 
         expect(ado_pm.accessible_ancestor_objects(u1, read, parent_fish, key: :unique_identifier).map(&:unique_identifier))

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -401,6 +401,12 @@ describe 'ActiveRecord' do
       expect(adapt.accessible_descendant_objects(u1, write, 0, key: :unique_identifier).map(&:unique_identifier) ).to eq( ['child_fish_1'] )
     end
 
+    it 'does not return objects which are not descendants of the specified object' do
+    end
+
+    it 'lists objects with the given privilege even if the privilege is not present on an intermediate object' do
+    end
+
     it 'filters objects via substring matching' do
       expect(adapt.accessible_descendant_objects(u1, read, 0, includes: 'fish', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['grandparent_fish','parent_fish'])
       expect(adapt.accessible_descendant_objects(u1, read, 0, includes: 'one', key: :unique_identifier).map(&:unique_identifier) ).to match_array(['grandparent_fish','child_fish_1'])


### PR DESCRIPTION
This PR adds a `accessible_ancestor_objects` method to the ActiveRecord storage adapter. This method adds object scoping to the existing `accessible_objects` method. An object is only "accessible" if it is an ancestor of the specified root object.
