### PR TITLE
Downversioned 'pg' gem to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.1
+* Downversioned 'pg' gem to '~> 0.15.0' to avoid v1.0.0 error with core Rails.
+
 ## 1.7.0
 * Add pluck_ancestor_tree method to ActiveRecord storage adapter.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     # Only required for mysql
     s.add_dependency('mysql2')
     # Only required for postgres
-    s.add_dependency('pg')
+    s.add_dependency('pg', '~> 0.15.0')
     s.add_dependency('activerecord-hierarchical_query', '~> 0.0')
 
   s.add_development_dependency('rspec', '~> 3.5.0')


### PR DESCRIPTION
Due to an error in the pg gem, v1.0.0 and its interaction with core Rails, we'll need to enforce a lower pg version for the PolicyMachine.

Once the error is patched will look into restoring the gem to v1.0.0+.