### PR TITLE
Loosen 'pg' gem dependency to '< 1.0.0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.2
+
+* Loosened 'pg' gem restriction to '< 1.0.0' for easier integration.
+
 ## 1.7.1
 * Downversioned 'pg' gem to '~> 0.15.0' to avoid v1.0.0 error with core Rails.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Changelog
 
 ## 1.7.2
-
-* Loosened 'pg' gem restriction to '< 1.0.0'.
+* Loosen 'pg' gem restriction to '< 1.0.0'.
 
 ## 1.7.1
-* Downversioned 'pg' gem to '~> 0.15.0' to avoid v1.0.0 error with core Rails.
+* Downversion 'pg' gem to '~> 0.15.0' to avoid v1.0.0 error with core Rails.
 
 ## 1.7.0
 * Add pluck_ancestor_tree method to ActiveRecord storage adapter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.7.2
 
-* Loosened 'pg' gem restriction to '< 1.0.0' for easier integration.
+* Loosened 'pg' gem restriction to '< 1.0.0'.
 
 ## 1.7.1
 * Downversioned 'pg' gem to '~> 0.15.0' to avoid v1.0.0 error with core Rails.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.7.1"
+  VERSION = "1.7.2"
 end

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     # Only required for mysql
     s.add_dependency('mysql2')
     # Only required for postgres
-    s.add_dependency('pg', '~> 0.15.0')
+    s.add_dependency('pg', '< 1.0.0')
     s.add_dependency('activerecord-hierarchical_query', '~> 0.0')
 
   s.add_development_dependency('rspec', '~> 3.5.0')


### PR DESCRIPTION
v1.7.1 of the Policy Machine added a '~> 0.15.0' version restriction to the 'pg' gem (dependency only when using an ActiveRecord storage adapter). Since 1.0.0 was the first 'pg' version which invalidated the Rails integration, this PR loosens the version requirement to sub-1.0.0.