### PR TITLE
[MCC-404025] Allow array parameters for finding records

### DIFF
--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.7.2"
+  VERSION = "1.7.3"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -566,7 +566,7 @@ module PolicyMachineStorageAdapter
       # i.e. ignore_case = [:name, :parent_uri], key = 'name'
       return true if ignore_case.respond_to?(:any?) && ignore_case.any? { |k| k.to_s == key }
 
-      return false
+      false
     end
 
     ##

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -476,13 +476,15 @@ module PolicyMachineStorageAdapter
       end
     end # End of POLICY_ELEMENT_TYPES iteration
 
-    # Arel matches provides agnostic case insensitive sql for MySQL and
-    # Postgres. This should always evaluate to an ActiveRecord_Relation.
+    # Given a policy element class and a set of conditions, returns an
+    # ActiveRecord_Relation with those conditions applied
     def build_active_record_relation(pe_class:, conditions:, ignore_case:)
       # If any condition is case-insensitive, the nodes need to be built
       # individually with Arel.
       if ignore_case
         conditions.map do |k, v|
+          # Arel matches provides agnostic case insensitive sql for MySQL and
+          # Postgres. This should always evaluate to an ActiveRecord_Relation.
           if ignore_case_applies?(ignore_case, k)
             build_arel_insensitive(pe_class: pe_class, key: k, value: v)
           else

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -839,8 +839,7 @@ module PolicyMachineStorageAdapter
             pe_matches_extra_attributes?(policy_element, key, value, ignore_case)
           end
 
-          memo.push(policy_element.id) if pe_within_scope
-          memo
+          pe_within_scope ? memo.push(policy_element.id) : memo
         end
 
         pe_class.where(id: ids)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -443,7 +443,8 @@ module PolicyMachineStorageAdapter
         # Generated PolicyElement class
         pe_class = class_for_type(pe_type)
 
-        # Arel matches provides agnostic case insensitive sql for mysql and postgres
+        # Arel matches provides agnostic case insensitive sql for MySQL and
+        # Postgres. This should always evaluate to an ActiveRecord_Relation.
         # If :ignore_case is not falsey..
         all = if options[:ignore_case]
                 # map over each condition..

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -518,7 +518,7 @@ module PolicyMachineStorageAdapter
       unless value.is_a?(Array)
         pe_class.arel_table[key].eq(value)
       else
-        if value.count > 0
+        unless value.empty?
           pe_class.arel_table[key].eq_any(value)
         else
           # Arel blows up with empty array passed to eq_any
@@ -531,7 +531,7 @@ module PolicyMachineStorageAdapter
     # Iterate over the input scope and return elements that match the extra
     # attribute conditions
     def filter_by_extra_attributes(scope:, extra_attribute_conditions:, pe_class:, ignore_case:)
-      if extra_attribute_conditions.count > 0
+      unless extra_attribute_conditions.empty?
         ids = scope.select do |pe|
           pe_within_scope = true
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -481,7 +481,12 @@ module PolicyMachineStorageAdapter
           Warn.once("WARNING: #{self.class} is filtering #{pe_type} on #{key} in memory, which won't scale well. " \
                     "To move this query to the database, add a '#{key}' column to the policy_elements table " \
                     "and re-save existing records")
-          all = all.select { |pe| pe_matches_extra_attributes?(pe, key, value, options[:ignore_case]) }
+
+          ids = all.select do |pe|
+            pe_matches_extra_attributes?(pe, key, value, options[:ignore_case])
+          end.map(&:id)
+
+          all = pe_class.where(id: ids)
         end
 
         # Default to first page if not specified

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -448,8 +448,15 @@ module PolicyMachineStorageAdapter
                 conditions.map do |k,v|
                   # if the ignore_case should apply to this condition..
                   if ignore_case_applies?(options[:ignore_case], k)
-                    # use case-insensitive SQL matching..
-                    pe_class.arel_table[k].matches(v)
+                    # and the passed parameter is not an array..
+                    unless v.is_a?(Array)
+                      # use case-insensitive SQL matching..
+                      pe_class.arel_table[k].matches(v)
+                    # and the passed parameter is an array..
+                    else
+                      # use case-insensitive SQL matching to the array..
+                      pe_class.arel_table[k].matches_any(v)
+                    end
                   else
                     # use case-sensitive SQL matching..
                     pe_class.arel_table[k].eq(v)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -772,9 +772,9 @@ module PolicyMachineStorageAdapter
     # Given a policy element class and a set of conditions, returns an
     # ActiveRecord_Relation with those conditions applied
     def build_active_record_relation(pe_class:, conditions:, ignore_case:)
-      # If any condition is case-insensitive, the nodes need to be built
-      # individually with Arel.
       if ignore_case
+        # If any condition is case-insensitive, the nodes need to be built
+        # individually with Arel.
         build_ignore_case_relation(
           pe_class: pe_class,
           conditions: conditions,

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -440,33 +440,33 @@ module PolicyMachineStorageAdapter
         # Generated PolicyElement class
         pe_class = class_for_type(pe_type)
 
-        results = build_active_record_relation(
+        relation = build_active_record_relation(
                     pe_class: pe_class,
                     conditions: conditions,
                     ignore_case: options[:ignore_case]
                   )
 
-        results = filter_by_include_conditions(
-                    scope: results,
+        relation = filter_by_include_conditions(
+                    scope: relation,
                     include_conditions: include_conditions,
                     klass: class_for_type(pe_type)
                   )
 
-        results = filter_by_extra_attributes(
-                    scope: results,
+        relation = filter_by_extra_attributes(
+                    scope: relation,
                     extra_attribute_conditions: extra_attribute_conditions,
                     pe_class: pe_class,
                     ignore_case: options[:ignore_case]
                   )
 
-        results = paginate_scope(scope: results, options: options)
+        relation = paginate_scope(scope: relation, options: options)
 
         # TODO: Look into moving this block into previous pagination conditional and test in consuming app
-        unless results.respond_to? :total_entries
-          results.define_singleton_method(:total_entries) { results.size }
+        unless relation.respond_to? :total_entries
+          relation.define_singleton_method(:total_entries) { relation.size }
         end
 
-        results
+        relation
       end
 
       define_method("pluck_all_of_type_#{pe_type}") do |fields:, options: {}|
@@ -769,8 +769,6 @@ module PolicyMachineStorageAdapter
       # individually with Arel.
       if ignore_case
         conditions.map do |k, v|
-          # Arel matches provides agnostic case insensitive sql for MySQL and
-          # Postgres. This should always evaluate to an ActiveRecord_Relation.
           if ignore_case_applies?(ignore_case, k)
             build_arel_insensitive(pe_class: pe_class, key: k, value: v)
           else

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -521,19 +521,29 @@ module PolicyMachineStorageAdapter
 
         if value.is_a?(Array)
           value.any? do |v|
-            if ignore_case_applies?(ignore_case, key) && attr_value.is_a?(String) && v.is_a?(String)
-              attr_value.downcase == v.downcase
-            else
-              attr_value == v
-            end
+            extra_attribute_match(
+              ignore_case: ignore_case,
+              key: key,
+              value_1: attr_value,
+              value_2: v
+            )
           end
         else
-          if ignore_case_applies?(ignore_case, key) && attr_value.is_a?(String) && value.is_a?(String)
-            attr_value.downcase == value.downcase
-          else
-            attr_value == value
-          end
+          extra_attribute_match(
+            ignore_case: ignore_case,
+            key: key,
+            value_1: attr_value,
+            value_2: value
+          )
         end
+      end
+    end
+
+    def extra_attribute_match(ignore_case:, key:, value_1:, value_2:)
+      if ignore_case_applies?(ignore_case, key) && value_1.is_a?(String) && value_2.is_a?(String)
+        value_1.downcase == value_2.downcase
+      else
+        value_1 == value_2
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -441,8 +441,6 @@ module PolicyMachineStorageAdapter
         # Generated PolicyElement class
         pe_class = class_for_type(pe_type)
 
-        # binding.pry
-
         # Arel matches provides agnostic case insensitive sql for mysql and postgres
         # If :ignore_case is not falsey..
         all = if options[:ignore_case]

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -807,22 +807,20 @@ module PolicyMachineStorageAdapter
     # Iterate over the input scope and return elements that match the extra
     # attribute conditions
     def filter_by_extra_attributes(scope:, extra_attribute_conditions:, pe_class:, ignore_case:)
-      unless extra_attribute_conditions.empty?
-        ids = scope.select do |pe|
-          pe_within_scope = true
-
-          extra_attribute_conditions.each do |key, value|
-            unless pe_matches_extra_attributes?(pe, key, value, ignore_case)
-              pe_within_scope = false
-            end
+      if extra_attribute_conditions.empty?
+        scope
+      else
+        ids = scope.reduce([]) do |memo, policy_element|
+          pe_within_scope = extra_attribute_conditions.all? do |key, value|
+            pe_matches_extra_attributes?(policy_element, key, value, ignore_case)
           end
 
-          pe_within_scope
-        end.map(&:id)
+          memo.push(policy_element.id) if pe_within_scope
+          memo
+        end
+
 
         pe_class.where(id: ids)
-      else
-        scope
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -459,10 +459,7 @@ module PolicyMachineStorageAdapter
                     ignore_case: options[:ignore_case]
                   )
 
-        results = paginate_scope(
-                    scope: results,
-                    options: options
-                  )
+        results = paginate_scope(scope: results, options: options)
 
         # TODO: Look into moving this block into previous pagination conditional and test in consuming app
         unless results.respond_to? :total_entries

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -505,7 +505,7 @@ module PolicyMachineStorageAdapter
       end
     end
 
-    # Build arel nodes using case-sensitive equality checking
+    # Build Arel nodes using case-sensitive equality checking
     def build_arel_sensitive(pe_class:, key:, value:)
       unless value.is_a?(Array)
         pe_class.arel_table[key].eq(value)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -432,6 +432,8 @@ module PolicyMachineStorageAdapter
       end
 
       define_method("find_all_of_type_#{pe_type}") do |options = {}|
+        # Map :uuid parameter to :unique_identifier
+        options[:unique_identifier] = options.delete(:uuid) if options[:uuid]
         # conditions: { "column": "matching value"} or {"column": ["matching 1", "matching 2"] }
         conditions = options.slice!(:per_page, :page, :ignore_case).stringify_keys
         # extra_attribute_conditions: like conditions, but attributes stored on :extra_attributes columns

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -843,7 +843,6 @@ module PolicyMachineStorageAdapter
           memo
         end
 
-
         pe_class.where(id: ids)
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -27,10 +27,10 @@ describe 'ActiveRecord' do
 
     describe 'find_all_of_type' do
       it 'accepts an array parameter on a column attribute' do
-        search_uuids = ['some_uuid1', 'some_uuid2']
+        search_uuids = [SecureRandom.uuid, SecureRandom.uuid]
         policy_machine_storage_adapter.add_object(search_uuids[0], 'some_policy_machine_uuid1')
         policy_machine_storage_adapter.add_object(search_uuids[1], 'some_policy_machine_uuid1')
-        policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1')
+        policy_machine_storage_adapter.add_object(SecureRandom.uuid, 'some_policy_machine_uuid1')
 
         expect(
           policy_machine_storage_adapter.find_all_of_type_object(
@@ -41,10 +41,11 @@ describe 'ActiveRecord' do
 
       context 'when case insensitive' do
         it 'accepts an array parameter on a column attribute' do
+          pm_uuid = SecureRandom.uuid
           colors = ['burnt_umber', 'mauve']
-          policy_machine_storage_adapter.add_object('some_uuid1', 'some_policy_machine_uuid1', color: colors[0])
-          policy_machine_storage_adapter.add_object('some_uuid2', 'some_policy_machine_uuid1', color: colors[1])
-          policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1', color: nil)
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: colors[0])
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: colors[1])
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: nil)
 
           expect(
             policy_machine_storage_adapter.find_all_of_type_object(
@@ -56,8 +57,8 @@ describe 'ActiveRecord' do
       end
 
       it 'allows uuid as a parameter' do
-        uuid = 'some_uuid'
-        policy_machine_storage_adapter.add_object(uuid, 'some_policy_machine_uuid')
+        uuid = SecureRandom.uuid
+        policy_machine_storage_adapter.add_object(uuid, SecureRandom.uuid)
 
         expect(
           policy_machine_storage_adapter.find_all_of_type_object(uuid: uuid).count
@@ -86,9 +87,10 @@ describe 'ActiveRecord' do
         end
 
         it 'only returns elements that match the hash' do
-          policy_machine_storage_adapter.add_object('some_uuid1', 'some_policy_machine_uuid1')
-          policy_machine_storage_adapter.add_object('some_uuid2', 'some_policy_machine_uuid1', color: 'red')
-          policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1', color: 'blue')
+          pm_uuid = SecureRandom.uuid
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid)
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: 'red')
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: 'blue')
           expect(policy_machine_storage_adapter.find_all_of_type_object(color: 'red')).to be_one
           expect(policy_machine_storage_adapter.find_all_of_type_object(color: nil)).to be_one
           expect(policy_machine_storage_adapter.find_all_of_type_object(color: 'green')).to be_none

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -26,11 +26,13 @@ describe 'ActiveRecord' do
     let(:policy_machine_storage_adapter) { described_class.new }
 
     describe 'find_all_of_type' do
+      let(:pm_uuid) { SecureRandom.uuid }
+
       it 'accepts an array parameter on a column attribute' do
         search_uuids = [SecureRandom.uuid, SecureRandom.uuid]
-        policy_machine_storage_adapter.add_object(search_uuids[0], 'some_policy_machine_uuid1')
-        policy_machine_storage_adapter.add_object(search_uuids[1], 'some_policy_machine_uuid1')
-        policy_machine_storage_adapter.add_object(SecureRandom.uuid, 'some_policy_machine_uuid1')
+        policy_machine_storage_adapter.add_object(search_uuids[0], pm_uuid)
+        policy_machine_storage_adapter.add_object(search_uuids[1], pm_uuid)
+        policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid)
 
         expect(
           policy_machine_storage_adapter.find_all_of_type_object(
@@ -58,7 +60,7 @@ describe 'ActiveRecord' do
 
       it 'allows uuid as a parameter' do
         uuid = SecureRandom.uuid
-        policy_machine_storage_adapter.add_object(uuid, SecureRandom.uuid)
+        policy_machine_storage_adapter.add_object(uuid, pm_uuid)
 
         expect(
           policy_machine_storage_adapter.find_all_of_type_object(uuid: uuid).count
@@ -74,9 +76,9 @@ describe 'ActiveRecord' do
         it 'accepts an array parameter' do
           foos = ['bar', 'baz']
           foos.each do |foo|
-            policy_machine_storage_adapter.add_object(SecureRandom.uuid, SecureRandom.uuid, foo: foo)
+            policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, foo: foo)
           end
-          policy_machine_storage_adapter.add_object(SecureRandom.uuid, SecureRandom.uuid, foo: nil)
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, foo: nil)
 
           result = policy_machine_storage_adapter.find_all_of_type_object(foo: foos)
 
@@ -87,7 +89,6 @@ describe 'ActiveRecord' do
         end
 
         it 'only returns elements that match the hash' do
-          pm_uuid = SecureRandom.uuid
           policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid)
           policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: 'red')
           policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: 'blue')
@@ -99,7 +100,7 @@ describe 'ActiveRecord' do
 
         context 'pagination' do
           before do
-            10.times {|i| policy_machine_storage_adapter.add_object("uuid_#{i}", 'some_policy_machine_uuid1', color: 'red') }
+            10.times {|i| policy_machine_storage_adapter.add_object("uuid_#{i}", pm_uuid, color: 'red') }
           end
 
           it 'paginates the results based on page and per_page' do

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -41,7 +41,7 @@ describe 'ActiveRecord' do
 
       context 'when case insensitive' do
         it 'accepts an array parameter on a column attribute' do
-          colors = ['some_uuid1', 'some_uuid2']
+          colors = ['burnt_umber', 'mauve']
           policy_machine_storage_adapter.add_object('some_uuid1', 'some_policy_machine_uuid1', color: colors[0])
           policy_machine_storage_adapter.add_object('some_uuid2', 'some_policy_machine_uuid1', color: colors[1])
           policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1', color: nil)
@@ -64,7 +64,7 @@ describe 'ActiveRecord' do
         ).to eq(1)
       end
 
-      context 'an extra attribute column has been added to the database' do
+      context 'when an extra attribute is used' do
         it 'does not warn' do
           expect(Warn).to_not receive(:warn)
           expect(policy_machine_storage_adapter.find_all_of_type_user(color: 'red')).to be_empty

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -63,6 +63,15 @@ describe 'ActiveRecord' do
         end
       end
 
+      it 'allows uuid as a parameter' do
+        uuid = 'some_uuid'
+        policy_machine_storage_adapter.add_object(uuid, 'some_policy_machine_uuid')
+
+        expect(
+          policy_machine_storage_adapter.find_all_of_type_object(uuid: uuid).count
+        ).to eq(1)
+      end
+
       context 'an extra attribute column has been added to the database' do
         it 'does not warn' do
           expect(Warn).to_not receive(:warn)

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -47,8 +47,23 @@ describe 'ActiveRecord' do
         ).to eq(2)
       end
 
-      context 'an extra attribute column has been added to the database' do
+      context 'when case insensitive' do
+        it 'accepts an array parameter on a column attribute' do
+          colors = ['some_uuid1', 'some_uuid2']
+          policy_machine_storage_adapter.add_object('some_uuid1', 'some_policy_machine_uuid1', color: colors[0])
+          policy_machine_storage_adapter.add_object('some_uuid2', 'some_policy_machine_uuid1', color: colors[1])
+          policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1', color: nil)
 
+          expect(
+            policy_machine_storage_adapter.find_all_of_type_object(
+              color: colors,
+              ignore_case: true
+            ).count
+          ).to eq(2)
+        end
+      end
+
+      context 'an extra attribute column has been added to the database' do
         it 'does not warn' do
           expect(Warn).to_not receive(:warn)
           expect(policy_machine_storage_adapter.find_all_of_type_user(color: 'red')).to be_empty

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -26,14 +26,6 @@ describe 'ActiveRecord' do
     let(:policy_machine_storage_adapter) { described_class.new }
 
     describe 'find_all_of_type' do
-
-      it 'warns once when filtering on an extra attribute' do
-        expect(Warn).to receive(:warn).once
-        2.times do
-          expect(policy_machine_storage_adapter.find_all_of_type_user(foo: 'bar')).to be_empty
-        end
-      end
-
       it 'accepts an array parameter on a column attribute' do
         search_uuids = ['some_uuid1', 'some_uuid2']
         policy_machine_storage_adapter.add_object(search_uuids[0], 'some_policy_machine_uuid1')

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -43,7 +43,6 @@ describe 'ActiveRecord' do
 
       context 'when case insensitive' do
         it 'accepts an array parameter on a column attribute' do
-          pm_uuid = SecureRandom.uuid
           colors = ['burnt_umber', 'mauve']
           policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: colors[0])
           policy_machine_storage_adapter.add_object(SecureRandom.uuid, pm_uuid, color: colors[1])

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -34,11 +34,39 @@ describe 'ActiveRecord' do
         end
       end
 
+      it 'accepts an array parameter on a column attribute' do
+        search_uuids = ['some_uuid1', 'some_uuid2']
+        policy_machine_storage_adapter.add_object(search_uuids[0], 'some_policy_machine_uuid1')
+        policy_machine_storage_adapter.add_object(search_uuids[1], 'some_policy_machine_uuid1')
+        policy_machine_storage_adapter.add_object('some_uuid3', 'some_policy_machine_uuid1')
+
+        expect(
+          policy_machine_storage_adapter.find_all_of_type_object(
+            unique_identifier: search_uuids
+          ).count
+        ).to eq(2)
+      end
+
       context 'an extra attribute column has been added to the database' do
 
         it 'does not warn' do
           expect(Warn).to_not receive(:warn)
           expect(policy_machine_storage_adapter.find_all_of_type_user(color: 'red')).to be_empty
+        end
+
+        it 'accepts an array parameter' do
+          foos = ['bar', 'baz']
+          foos.each do |foo|
+            policy_machine_storage_adapter.add_object(SecureRandom.uuid, SecureRandom.uuid, foo: foo)
+          end
+          policy_machine_storage_adapter.add_object(SecureRandom.uuid, SecureRandom.uuid, foo: nil)
+
+          result = policy_machine_storage_adapter.find_all_of_type_object(foo: foos)
+
+          expect(result.count).to eq(2)
+          foos.each do |foo|
+            expect(result.map(&:foo)).to include(foo)
+          end
         end
 
         it 'only returns elements that match the hash' do


### PR DESCRIPTION
This PR modifies the `find_all_of_type_#{pe_type}` method definition to allow for passing arrays as arguments to find records matching any of the elements in the array. 

Previously, this worked with only very specific conditions due to the logic that determines the `all` variable. I believe that you could pass arrays when finding based on a column attribute besides `name`. 

Note that this method still is extremely inefficient for querying on the `extra_attributes` column, as all searching is done in-memory. There is still a **lot** of potential performance improvements in this method, and it's used frequently enough that I think work in the future could drastically improve performance across many workflows. 

@mdsol/team04 - please review.