### PR TITLE
[MCC-404025] Make class_for_type public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## 1.7.4
+* Re-expose the 'class_for_type' method to the public interface. 
+
 ## 1.7.3
 * Improve find_all_of_type_* functionality. This allows for properly passing
   arrays as arguments as well as making the ignore_case parameter work as
-  intended. 
+  intended.
 
 ## 1.7.2
 * Loosen 'pg' gem restriction to '< 1.0.0'.

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -483,6 +483,11 @@ module PolicyMachineStorageAdapter
       end
     end # End of POLICY_ELEMENT_TYPES iteration
 
+    def class_for_type(pe_type)
+      @pe_type_class_hash ||= Hash.new { |h,k| h[k] = "PolicyMachineStorageAdapter::ActiveRecord::#{k.camelize}".constantize }
+      @pe_type_class_hash[pe_type]
+    end
+
     ##
     # Assign src to dst in policy machine.
     # The two policy elements must be persisted policy elements
@@ -872,11 +877,6 @@ module PolicyMachineStorageAdapter
     # Note: If we start accepting literal hash values this may need to start checking the key's column type
     def include_condition?(key, value)
       value.respond_to?(:keys) && value.keys.map(&:to_sym) == [:include]
-    end
-
-    def class_for_type(pe_type)
-      @pe_type_class_hash ||= Hash.new { |h,k| h[k] = "PolicyMachineStorageAdapter::ActiveRecord::#{k.camelize}".constantize }
-      @pe_type_class_hash[pe_type]
     end
 
     # Check if the PolicyElement's extra_attributes column includes the passed


### PR DESCRIPTION
This PR fixes the public interface of the PM to expose the `class_for_type` method. 


