### PR TITLE
[MCC-404025] Bump PM versionj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## 1.7.4
+* Re-expose the 'class_for_type' method to the public interface. 
+
 ## 1.7.3
 * Improve find_all_of_type_* functionality. This allows for properly passing
   arrays as arguments as well as making the ignore_case parameter work as
-  intended. 
+  intended.
 
 ## 1.7.2
 * Loosen 'pg' gem restriction to '< 1.0.0'.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.7.3"
+  VERSION = "1.7.4"
 end


### PR DESCRIPTION
This PR bumps the version number in `version.rb`. 