### PR TITLE
[MCC-409765] Update PM to utilize soft deletion functionality in privilege calls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## 1.8.1
+* Add soft deletion support to the ActiveRecord storage adapter.
+
 ## 1.8.0
 * Add accessible_ancestor_objects method to ActiveRecord storage adapter.
 
 ## 1.7.4
-* Re-expose the 'class_for_type' method to the public interface. 
+* Re-expose the 'class_for_type' method to the public interface.
 
 ## 1.7.3
 * Improve find_all_of_type_* functionality. This allows for properly passing

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.8.0"
+  VERSION = "1.8.1"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -745,7 +745,11 @@ module PolicyMachineStorageAdapter
 
       user_attributes = user_or_attribute.descendants | [user_or_attribute]
       associations = PolicyElementAssociation.where(user_attribute_id: user_attributes.map(&:id))
-      operation_set_ids = associations.pluck(:operation_set_id)
+      operation_set_ids = if options[:use_soft_deleted_data]
+                            associations.pluck(:operation_set_id)
+                          else
+                            OperationSet.where(id: associations.select(:operation_set_id), deleted_at: nil).pluck(:id)
+                          end
 
       filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
       filtered_associations =
@@ -785,14 +789,18 @@ module PolicyMachineStorageAdapter
 
       # Short-circuit and return all ancestors (minus prohibitions) if the user_or_attribute
       # is authorized on the root node
-      if is_privilege?(user_or_attribute, operation, root_object_stored_pe)
+      if is_privilege?(user_or_attribute, operation, root_object_stored_pe, options)
         return all_ancestor_objects(user_or_attribute, operation, root_object_stored_pe, ancestor_objects, options)
       end
 
       # Fetch all of the PEAs using the given UA or its descendants
       user_attribute_ids = user_or_attribute.descendants.pluck(:id) | [user_or_attribute.id]
       associations = PolicyElementAssociation.where(user_attribute_id: user_attribute_ids)
-      operation_set_ids = associations.pluck(:operation_set_id)
+      operation_set_ids = if options[:use_soft_deleted_data]
+                            associations.pluck(:operation_set_id)
+                          else
+                            OperationSet.where(id: associations.select(:operation_set_id), deleted_at: nil).pluck(:id)
+                          end
 
       # Narrow the list of PEAs to just those containing the specified operation
       operation_id = operation.try(:unique_identifier) || operation.to_s

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -1008,10 +1008,10 @@ module PolicyMachineStorageAdapter
         prms.merge!(unique_identifier: operation_id) if operation_id
 
         operation_sets = if options[:use_soft_deleted_data]
-          associations.map(&:operation_sets)
-        else
-          OperationSet.where(id: associations.select(:operation_set_id), deleted_at: nil)
-        end
+                           associations.map(&:operation_set)
+                         else
+                           OperationSet.where(id: associations.select(:operation_set_id), deleted_at: nil)
+                         end
 
         Assignment.descendants_of(operation_sets).where(prms)
       end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -425,8 +425,32 @@ describe 'ActiveRecord' do
     context 'when an operation set is soft deleted' do
       before { @op_set.update(deleted_at: Time.now) }
 
-      it 'does not grant a privilege' do
-        expect(@pm.is_privilege?(@u1, @op, @o)).to be_falsey
+      describe '.is_privilege?' do
+        it 'does not grant a privilege via the operation set' do
+          expect(@pm.is_privilege?(@u1, @op, @o)).to be_falsey
+        end
+      end
+
+      describe '.is_privilege_ignoring_prohibitions?' do
+        it 'does not grant a privilege via the operation set' do
+          expect(@pm.is_privilege_ignoring_prohibitions?(@u1, @op, @o)).to be_falsey
+        end
+      end
+
+      context 'when use_soft_deleted_data is passed' do
+        let(:options) { { use_soft_deleted_data: true } }
+
+        describe '.is_privilege?' do
+          it 'grants a privilege via the soft deleted operation set' do
+            expect(@pm.is_privilege?(@u1, @op, @o, options)).to be_truthy
+          end
+        end
+
+        describe '.is_privilege_ignoring_prohibitions?' do
+          it 'grants a privilege via the soft deleted operation set' do
+            expect(@pm.is_privilege_ignoring_prohibitions?(@u1, @op, @o, options)).to be_truthy 
+          end
+        end
       end
     end
   end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -448,7 +448,7 @@ describe 'ActiveRecord' do
 
         describe '.is_privilege_ignoring_prohibitions?' do
           it 'grants a privilege via the soft deleted operation set' do
-            expect(@pm.is_privilege_ignoring_prohibitions?(@u1, @op, @o, options)).to be_truthy 
+            expect(@pm.is_privilege_ignoring_prohibitions?(@u1, @op, @o, options)).to be_truthy
           end
         end
       end
@@ -520,6 +520,14 @@ describe 'ActiveRecord' do
       all_accessible_from_uncle = ado_pm.accessible_ancestor_objects(u1, read, uncle_fish, key: :unique_identifier)
 
       expect(all_accessible_from_uncle.map(&:unique_identifier)).to contain_exactly('uncle_fish', 'cousin_fish')
+    end
+
+    context 'when the operation set is soft deleted' do
+      before { writer.update(deleted_at: Time.now) }
+
+      it 'does not list objects with the privilege given by the operation set' do
+        expect(ado_pm.accessible_ancestor_objects(u1, write, grandparent_fish, key: :unique_identifier).map(&:unique_identifier)).to be_empty 
+      end
     end
 
     it 'lists objects with the given privilege even if the privilege is not present on an intermediate object' do

--- a/test/add_test_columns_migration.rb
+++ b/test/add_test_columns_migration.rb
@@ -4,6 +4,7 @@ class AddTestColumns < ActiveRecord::Migration
     if ActiveRecord::Base.connection.class.name == 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter'
       add_column :policy_elements, :tags, 'text[]'
       add_column :policy_elements, :document, :jsonb, default: '{}'
+      add_column :policy_elements, :deleted_at, :datetime  
     else
       add_column :policy_elements, :tags, :text
     end


### PR DESCRIPTION
This PR updates the Police Machine to utilize soft deletion functionality in ActiveRecord privilege calls. 

It modifies: 
1. The `is_privilege?` definition on the ActiveRecord adapter by adding default behavior to ignore soft deleted data, with an optional hash parameter that can change this behavior by passing `true` to the `:use_soft_deleted_data` key 
2. The PM test app setup in relation to ActiveRecord adapter testing by adding a deleted_at column
3. Specs for `is_privilege?` calls and `is_privilege_without_prohibitions?` calls on the ActiveRecord adapter

@mdsol/team04 - please review. 