### PR TITLE
[MCC-224756] Privileges scoped by role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.9.0
 * Add `is_privilege_in_role?` method to ActiveRecord storage adapter.
 * Update `accessible_ancestor_objects`, `accessible_objects`, `scoped_privileges`, and `accessible_operations` methods in the ActiveRecord storage adapter to accept scoping to a user attribute.
+* Update `is_privilege_ignoring_prohibitions?` to accept an optional user attribute scope.
 
 ## 1.8.1
 * Refactor `accessible_ancestor_objects` and `accessible_objects`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.0
+* Add `is_privilege_in_role?` method to ActiveRecord storage adapter.
+* Update `accessible_ancestor_objects`, `accessible_objects`, `scoped_privileges`, and `accessible_operations` methods in the ActiveRecord storage adapter to accept scoping to a user attribute.
+
 ## 1.8.1
 * Refactor `accessible_ancestor_objects` and `accessible_objects`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.9.0
-* Add `is_privilege_in_role?` method to ActiveRecord storage adapter.
+* Add `is_privilege_via_attribute?` method to ActiveRecord storage adapter.
 * Update `accessible_ancestor_objects`, `accessible_objects`, `scoped_privileges`, and `accessible_operations` methods in the ActiveRecord storage adapter to accept scoping to a user attribute.
 * Update `is_privilege_ignoring_prohibitions?` to accept an optional user attribute scope.
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -282,7 +282,8 @@ class PolicyMachine
   end
 
   def is_privilege_in_role?(user_or_attribute, operation, object_or_attribute, user_attribute_scope, options = {})
-    is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope) && (options[:ignore_prohibitions] || !is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, user_attribute_scope))
+    # Prohibitions shouldn't ever be scoped to role, so use the normal privilege check for the prohibition
+    is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute))
   end
 
   def is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -212,6 +212,9 @@ class PolicyMachine
     end
 
     if user_attribute_scope
+      # TODO: Surface user attribute origin in scoped_privileges_and_prohibitions
+      # so this call is unnecessary and the user attribute scoping can be done
+      # in-memory while maintaining the full set of prohibitions
       scoped_privs = scoped_privileges_and_prohibitions(
         user_or_attribute,
         object_or_attribute,

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -115,12 +115,12 @@ class PolicyMachine
       return policy_machine_storage_adapter.is_privilege?(*privilege)
     end
 
-    if (user_attribute_scope = options[:user_attribute_scope]) && policy_machine_storage_adapter.respond_to?(:is_privilege_in_role?)
+    if (user_attribute_scope = options[:user_attribute_scope]) && policy_machine_storage_adapter.respond_to?(:is_privilege_via_attribute?)
       privilege = [user_or_attribute, operation, object_or_attribute, user_attribute_scope].map do |obj|
         obj.respond_to?(:stored_pe) ? obj.stored_pe : obj
       end
 
-      return policy_machine_storage_adapter.is_privilege_in_role?(*privilege)
+      return policy_machine_storage_adapter.is_privilege_via_attribute?(*privilege)
     end
 
     unless operation.is_a?(PM::Operation)
@@ -299,16 +299,16 @@ class PolicyMachine
     end
   end
 
-  def is_privilege_in_role?(user_or_attribute, operation, object_or_attribute, user_attribute_scope, options = {})
-    # Prohibitions shouldn't ever be scoped to role, so use the normal privilege check for the prohibition
-    is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute))
+  def is_privilege_via_attribute?(user_or_attribute, operation, object_or_attribute, user_attribute_scope, options = {})
+    # Prohibitions shouldn't ever be scoped to a user attribute, so use the normal privilege check for the prohibition
+    is_privilege_via_attribute_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute))
   end
 
-  def is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
-    if policy_machine_storage_adapter.respond_to?(:is_privilege_in_role?)
-      policy_machine_storage_adapter.is_privilege_in_role?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
+  def is_privilege_via_attribute_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
+    if policy_machine_storage_adapter.respond_to?(:is_privilege_via_attribute?)
+      policy_machine_storage_adapter.is_privilege_via_attribute?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
     else
-      raise NoMethodError, "is_privilege_in_role? is not implemented for storage adapter " \
+      raise NoMethodError, "is_privilege_via_attribute? is not implemented for storage adapter " \
         "#{policy_machine_storage_adapter.class}"
     end
   end

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -116,7 +116,10 @@ class PolicyMachine
     end
 
     if (user_attribute_scope = options[:user_attribute_scope]) && policy_machine_storage_adapter.respond_to?(:is_privilege_in_role?)
-      privilege = [user_or_attribute, operation, object_or_attribute, user_attribute_scope].map { |obj| obj.respond_to?(:stored_pe) ? obj.stored_pe : obj }
+      privilege = [user_or_attribute, operation, object_or_attribute, user_attribute_scope].map do |obj|
+        obj.respond_to?(:stored_pe) ? obj.stored_pe : obj
+      end
+
       return policy_machine_storage_adapter.is_privilege_in_role?(*privilege)
     end
 
@@ -199,15 +202,17 @@ class PolicyMachine
   #
   # TODO:  might make privilege a class of its own
   def scoped_privileges(user_or_attribute, object_or_attribute, options = {})
+    # Duplicate so passed hash doesn't get modified
+    options = options.dup
     user_attribute_scope = options.delete(:user_attribute_scope)
 
     privs_and_prohibs = scoped_privileges_and_prohibitions(user_or_attribute, object_or_attribute, options)
 
     prohibited_operations = Set.new
 
-    privileges = privs_and_prohibs.reject do |_, op, _|
-      if op.prohibition?
-        prohibited_operations.add(op.operation)
+    privileges = privs_and_prohibs.reject do |_, operation, _|
+      if operation.prohibition?
+        prohibited_operations.add(operation.operation)
       end
     end
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -115,6 +115,11 @@ class PolicyMachine
       return policy_machine_storage_adapter.is_privilege?(*privilege)
     end
 
+    if (user_attribute_scope = options[:user_attribute_scope]) && policy_machine_storage_adapter.respond_to?(:is_privilege_in_role?)
+      privilege = [user_or_attribute, operation, object_or_attribute, user_attribute_scope].map { |obj| obj.respond_to?(:stored_pe) ? obj.stored_pe : obj }
+      return policy_machine_storage_adapter.is_privilege_in_role?(*privilege)
+    end
+
     unless operation.is_a?(PM::Operation)
       operation = operations(unique_identifier: operation.to_s).first or return false
     end

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -276,6 +276,19 @@ class PolicyMachine
     end
   end
 
+  def is_privilege_in_role?(user_or_attribute, operation, object_or_attribute, user_attribute_scope, options = {})
+    is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope) && (options[:ignore_prohibitions] || !is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, user_attribute_scope))
+  end
+
+  def is_privilege_in_role_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
+    if policy_machine_storage_adapter.respond_to?(:is_privilege_in_role?)
+      policy_machine_storage_adapter.is_privilege_in_role?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
+    else
+      raise NoMethodError, "is_privilege_in_role? is not implemented for storage adapter " \
+        "#{policy_machine_storage_adapter.class}"
+    end
+  end
+
   ##
   # Returns an array of all user_attributes a PM::User is assigned to,
   # directly or indirectly.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.8.1"
+  VERSION = "1.9.0"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -709,6 +709,8 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    # Returns true if the user has the operation on the object, and that operation is granted by
+    # the user attribute scope or its descendants
     def is_privilege_in_role?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
       policy_classes_containing_object = policy_classes_for_object_attribute(object_or_attribute)
       operation_id = operation.try(:unique_identifier) || operation.to_s
@@ -724,15 +726,20 @@ module PolicyMachineStorageAdapter
 
     ## Optimized version of PolicyMachine#scoped_privileges
     # Returns all operations the user has on the object
+    # A user attribute scope can be passed in the options hash as :user_attribute_scope
+    # The only privileges returns will be those granted by the user attribute scope or its
+    # descendants
     def scoped_privileges(user_or_attribute, object_or_attribute, options = {})
       policy_classes_containing_object = policy_classes_for_object_attribute(object_or_attribute)
 
+      user_attribute_scope = options[:user_attribute_scope]
+
       operations =
         if policy_classes_containing_object.size < 2
-          accessible_operations(user_or_attribute, object_or_attribute)
+          accessible_operations(user_or_attribute, object_or_attribute, nil, user_attribute_scope)
         else
           policy_classes_containing_object.flat_map do |policy_class|
-            accessible_operations(user_or_attribute, policy_class.ancestors)
+            accessible_operations(user_or_attribute, policy_class.ancestors, nil, user_attribute_scope)
           end
         end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -768,6 +768,7 @@ module PolicyMachineStorageAdapter
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation))
         candidates
       else
+        options.delete(:user_attribute_scope)
         candidates - accessible_objects(user_or_attribute, prohibition, options.merge(ignore_prohibitions: true))
       end
     end
@@ -798,6 +799,7 @@ module PolicyMachineStorageAdapter
         candidates
       else
         preloaded_options = options.merge(ignore_prohibitions: true, ancestor_objects: ancestor_objects)
+        preloaded_options.delete(:user_attribute_scope)
         candidates - accessible_ancestor_objects(user_or_attribute, prohibition, root_object, preloaded_options)
       end
     end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -825,8 +825,8 @@ module PolicyMachineStorageAdapter
       user_attribute_ids = user_or_attribute.descendants.pluck(:id) | [user_or_attribute.id]
 
       if user_attribute_scope = options[:user_attribute_scope]
-        user_attribute_scope_ids = user_attribute_scope.respond_to?(:map) ? user_attribute_scope.map(&:id) : user_attribute_scope.id
-        scoped_user_attribute_ids = Assignment.descendants_of(user_attribute_scope).pluck(:id) | [user_attribute_scope_ids]
+        user_attribute_scope_ids = user_attribute_scope.respond_to?(:map) ? user_attribute_scope.map(&:id) : [user_attribute_scope.id]
+        scoped_user_attribute_ids = Assignment.descendants_of(user_attribute_scope).pluck(:id) | user_attribute_scope_ids
         user_attribute_ids = user_attribute_ids & scoped_user_attribute_ids
       end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -1056,6 +1056,8 @@ module PolicyMachineStorageAdapter
       apply_include_condition!(ancestor_objects, options[:key], options[:includes])
 
       if !options[:ignore_prohibitions] && prohibition = prohibition_for(operation)
+        options.delete(:user_attribute_scope)
+
         prohibited_ancestor_objects = accessible_ancestor_objects(
           user_or_attribute,
           prohibition,

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -665,7 +665,7 @@ module PolicyMachineStorageAdapter
     def associations_with(operation)
       params = { type: PolicyMachineStorageAdapter::ActiveRecord::OperationSet.to_s }
       operation_sets = Assignment.ancestors_of(operation).where(params)
-      assocs = PolicyElementAssociation.where(operation_set_id: operation_sets.pluck(:id))
+      assocs = PolicyElementAssociation.where(operation_set_id: operation_sets.select(:id))
 
       assocs.map do |assoc|
         assoc.clear_association_cache #TODO Either do this better (touch through HABTM on bulk insert?) or dont do this?
@@ -849,7 +849,7 @@ module PolicyMachineStorageAdapter
     # Builds an array of PolicyElement objects within the scope of a given
     # array of associations
     def build_accessible_object_scope(associations, options = {})
-      permitting_oas = PolicyElement.where(id: associations.pluck(:object_attribute_id))
+      permitting_oas = PolicyElement.where(id: associations.select(:object_attribute_id))
 
       # Direct scope: the set of objects on which the operator is directly assigned
       direct_scope = permitting_oas.where(type: class_for_type('object'))

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -711,7 +711,7 @@ module PolicyMachineStorageAdapter
 
     # Returns true if the user has the operation on the object, and that operation is granted by
     # the user attribute scope or its descendants
-    def is_privilege_in_role?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
+    def is_privilege_via_attribute?(user_or_attribute, operation, object_or_attribute, user_attribute_scope)
       policy_classes_containing_object = policy_classes_for_object_attribute(object_or_attribute)
       operation_id = operation.try(:unique_identifier) || operation.to_s
 
@@ -812,7 +812,7 @@ module PolicyMachineStorageAdapter
     # Return true if the user_or_attribute is authorized on the root object
     def short_circuit_all_ancestor_objects?(user_or_attribute, operation, root_object, options)
       if user_attribute_scope = options[:user_attribute_scope]
-        is_privilege_in_role?(user_or_attribute, operation, root_object, user_attribute_scope)
+        is_privilege_via_attribute?(user_or_attribute, operation, root_object, user_attribute_scope)
       else
         is_privilege?(user_or_attribute, operation, root_object)
       end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -717,7 +717,7 @@ module PolicyMachineStorageAdapter
         !accessible_operations(user_or_attribute, object_or_attribute, operation_id, user_attribute_scope).empty?
       else
         policy_classes_containing_object.all? do |policy_class|
-          # todo
+          !accessible_operations(user_or_attribute, object_or_attribute, operation_id, user_attribute_scope).empty?
         end
       end
     end
@@ -752,6 +752,8 @@ module PolicyMachineStorageAdapter
 
     ## Optimized version of PolicyMachine#accessible_objects
     # Returns all objects the user has the given operation on
+    # A user attribute scope can be passed in the options hash as :user_attribute_scope
+    # The only objects that will be returned are those that are accessible via the user attribute scope
     # TODO: Support multiple policy classes here
     def accessible_objects(user_or_attribute, operation, options = {})
       candidates = objects_for_user_or_attribute_and_operation(user_or_attribute, operation, options)
@@ -765,6 +767,8 @@ module PolicyMachineStorageAdapter
 
     # Version of accessible_objects which only returns objects that are
     # ancestors of a specified root object or the object itself
+    # A user attribute scope can be passed in the options hash as :user_attribute_scope
+    # The only objects that will be returned are those that are accessible via the user attribute scope
     def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
       # If the root_object is a generic PM::Object, convert it the appropriate storage adapter Object
       root_object = root_object.try(:stored_pe) || root_object

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -763,6 +763,8 @@ module PolicyMachineStorageAdapter
     # The only objects that will be returned are those that are accessible via the user attribute scope
     # TODO: Support multiple policy classes here
     def accessible_objects(user_or_attribute, operation, options = {})
+      # Duplicate so passed hash doesn't get modified
+      options = options.dup
       candidates = objects_for_user_or_attribute_and_operation(user_or_attribute, operation, options)
 
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation))
@@ -809,9 +811,9 @@ module PolicyMachineStorageAdapter
     # Return true if the user_or_attribute is authorized on the root object
     def short_circuit_all_ancestor_objects?(user_or_attribute, operation, root_object, options)
       if user_attribute_scope = options[:user_attribute_scope]
-        true if is_privilege_in_role?(user_or_attribute, operation, root_object, user_attribute_scope)
+        is_privilege_in_role?(user_or_attribute, operation, root_object, user_attribute_scope)
       else
-        true if is_privilege?(user_or_attribute, operation, root_object)
+        is_privilege?(user_or_attribute, operation, root_object)
       end
     end
 
@@ -829,7 +831,7 @@ module PolicyMachineStorageAdapter
       if user_attribute_scope = options[:user_attribute_scope]
         user_attribute_scope_ids = user_attribute_scope.respond_to?(:map) ? user_attribute_scope.map(&:id) : [user_attribute_scope.id]
         scoped_user_attribute_ids = Assignment.descendants_of(user_attribute_scope).pluck(:id) | user_attribute_scope_ids
-        user_attribute_ids = user_attribute_ids & scoped_user_attribute_ids
+        user_attribute_ids &= scoped_user_attribute_ids
       end
 
       PolicyElementAssociation.where(user_attribute_id: user_attribute_ids)
@@ -1034,7 +1036,7 @@ module PolicyMachineStorageAdapter
 
         if user_attribute_scope
           scoped_user_attribute_ids = Assignment.descendants_of(user_attribute_scope).pluck(:id) | [user_attribute_scope.id]
-          user_attribute_ids = user_attribute_ids & scoped_user_attribute_ids
+          user_attribute_ids &= scoped_user_attribute_ids
         end
 
         associations =

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -665,7 +665,7 @@ module PolicyMachineStorageAdapter
     def associations_with(operation)
       params = { type: PolicyMachineStorageAdapter::ActiveRecord::OperationSet.to_s }
       operation_sets = Assignment.ancestors_of(operation).where(params)
-      assocs = PolicyElementAssociation.where(operation_set_id: operation_sets.select(:id))
+      assocs = PolicyElementAssociation.where(operation_set_id: operation_sets.pluck(:id))
 
       assocs.map do |assoc|
         assoc.clear_association_cache #TODO Either do this better (touch through HABTM on bulk insert?) or dont do this?

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -770,6 +770,7 @@ module PolicyMachineStorageAdapter
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation))
         candidates
       else
+        options = options.dup
         options.delete(:user_attribute_scope)
         candidates - accessible_objects(user_or_attribute, prohibition, options.merge(ignore_prohibitions: true))
       end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -825,7 +825,8 @@ module PolicyMachineStorageAdapter
       user_attribute_ids = user_or_attribute.descendants.pluck(:id) | [user_or_attribute.id]
 
       if user_attribute_scope = options[:user_attribute_scope]
-        scoped_user_attribute_ids = Assignment.descendants_of(user_attribute_scope).pluck(:id) | [user_attribute_scope.id]
+        user_attribute_scope_ids = user_attribute_scope.respond_to?(:map) ? user_attribute_scope.map(&:id) : user_attribute_scope.id
+        scoped_user_attribute_ids = Assignment.descendants_of(user_attribute_scope).pluck(:id) | [user_attribute_scope_ids]
         user_attribute_ids = user_attribute_ids & scoped_user_attribute_ids
       end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -25,7 +25,7 @@ describe 'ActiveRecord' do
     it_behaves_like 'a policy machine storage adapter'
     let(:policy_machine_storage_adapter) { described_class.new }
 
-    describe 'scoping privileges by role' do
+    describe 'scoping privileges by user attribute' do
       let(:candy_pm) { PolicyMachine.new(name: 'Candy Machine', storage_adapter: PolicyMachineStorageAdapter::ActiveRecord)}
 
       let(:frank) { candy_pm.create_user('frank') }
@@ -94,11 +94,11 @@ describe 'ActiveRecord' do
         candy_pm.add_association(ice_cream_engineer, creator, ice_creams)
       end
 
-      describe 'is_privilege_in_role?' do
+      describe 'is_privilege_via_attribute?' do
         context 'when the user has access via an operation set' do
           it 'returns true' do
             expect(
-              candy_pm.is_privilege_in_role?(frank, create, brie, cheese_engineer)
+              candy_pm.is_privilege_via_attribute?(frank, create, brie, cheese_engineer)
             ).to be_truthy
           end
 
@@ -112,7 +112,7 @@ describe 'ActiveRecord' do
 
             it 'returns false' do
               expect(
-                candy_pm.is_privilege_in_role?(frank, create, brie, cheese_engineer)
+                candy_pm.is_privilege_via_attribute?(frank, create, brie, cheese_engineer)
               ).to be_falsey
             end
           end
@@ -128,7 +128,7 @@ describe 'ActiveRecord' do
 
           it 'returns true' do
             expect(
-              candy_pm.is_privilege_in_role?(frank, create, money, cheese_engineer)
+              candy_pm.is_privilege_via_attribute?(frank, create, money, cheese_engineer)
             ).to be_truthy
           end
         end
@@ -136,7 +136,7 @@ describe 'ActiveRecord' do
         context 'when the user has access via a different operation set' do
           it 'returns false' do
             expect(
-              candy_pm.is_privilege_in_role?(frank, create, brie, employee)
+              candy_pm.is_privilege_via_attribute?(frank, create, brie, employee)
             ).to be_falsey
           end
         end
@@ -144,7 +144,7 @@ describe 'ActiveRecord' do
         context 'when the user does not have access via any operation set' do
           it 'returns false' do
             expect(
-              candy_pm.is_privilege_in_role?(frank, create, money, cheese_engineer)
+              candy_pm.is_privilege_via_attribute?(frank, create, money, cheese_engineer)
             ).to be_falsey
           end
         end
@@ -152,7 +152,7 @@ describe 'ActiveRecord' do
 
       describe 'scoped_privileges' do
         context 'when the user has access via an operation set' do
-          it 'returns all the privileges granted by that role' do
+          it 'returns all the privileges granted by that attribute' do
             expect(
               candy_pm.scoped_privileges(
                 frank,
@@ -197,8 +197,8 @@ describe 'ActiveRecord' do
         end
 
         context 'when a user_attribute_scope option is passed' do
-          it 'calls is_privilege_in_role?' do
-            expect(candy_pm.policy_machine_storage_adapter).to receive(:is_privilege_in_role?)
+          it 'calls is_privilege_via_attribute?' do
+            expect(candy_pm.policy_machine_storage_adapter).to receive(:is_privilege_via_attribute?)
             candy_pm.is_privilege_ignoring_prohibitions?(
               frank,
               create,
@@ -221,7 +221,7 @@ describe 'ActiveRecord' do
       end
 
       describe 'accessible_objects' do
-        it 'returns objects accessible via a role' do
+        it 'returns objects accessible via an attribute' do
           expect(
             candy_pm.accessible_objects(
               frank,
@@ -232,7 +232,7 @@ describe 'ActiveRecord' do
           ).to match_array(['brie', 'swiss'])
         end
 
-        it 'does not return objects that are not accessible via a role' do
+        it 'does not return objects that are not accessible via an attribute' do
           expect(
             candy_pm.accessible_objects(frank, create, user_attribute_scope: employee)
           ).to be_empty
@@ -260,7 +260,7 @@ describe 'ActiveRecord' do
       end
 
       describe 'accessible_ancestor_objects' do
-        it 'returns objects accessible via a role on an object scope' do
+        it 'returns objects accessible via an attribute on an object scope' do
           expect(
             candy_pm.accessible_ancestor_objects(
               frank,
@@ -272,7 +272,7 @@ describe 'ActiveRecord' do
           ).to match_array(['vanilla', 'french_vanilla', 'american_vanilla'])
         end
 
-        it 'does not return objects that are not accessible via a role on an object scope' do
+        it 'does not return objects that are not accessible via an attribute on an object scope' do
           expect(
             candy_pm.accessible_ancestor_objects(frank, create, vanilla, user_attribute_scope: employee)
           ).to be_empty

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -150,6 +150,44 @@ describe 'ActiveRecord' do
         end
       end
 
+      describe 'scoped_privileges' do
+        context 'when the user has access via an operation set' do
+          it 'returns all the privileges granted by that role' do
+            expect(
+              candy_pm.scoped_privileges(
+                frank,
+                brie,
+                user_attribute_scope: cheese_engineer
+              )
+            ).to match_array([[frank, create, brie], [frank, taste, brie]])
+          end
+        end
+
+        context 'when the user has access via a different operation set' do
+          it 'does not return the privilege given by the other operation set' do
+            expect(
+              candy_pm.scoped_privileges(
+                frank,
+                brie,
+                user_attribute_scope: ice_cream_engineer
+              )
+            ).to_not include([frank, create, brie])
+          end
+        end
+
+        context 'when the user does not have access via any operation set' do
+          it 'returns an empty array' do
+            expect(
+              candy_pm.scoped_privileges(
+                frank,
+                money,
+                user_attribute_scope: cheese_engineer
+              )
+            ).to be_empty
+          end
+        end
+      end
+
       describe 'accessible_objects' do
         it 'returns objects accessible via a role' do
           expect(

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -159,7 +159,7 @@ describe 'ActiveRecord' do
                 brie,
                 user_attribute_scope: cheese_engineer
               )
-            ).to match_array([[frank, create, brie], [frank, taste, brie]])
+            ).to contain_exactly([frank, create, brie], [frank, taste, brie])
           end
         end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -188,6 +188,38 @@ describe 'ActiveRecord' do
         end
       end
 
+      describe 'is_privilege_ignoring_prohibitions?' do
+        let(:cant_create) { candy_pm.create_operation_set('cant_create') }
+
+        before do
+          candy_pm.add_assignment(cant_create, create.prohibition)
+          candy_pm.add_association(cheese_engineer, cant_create, brie)
+        end
+
+        context 'when a user_attribute_scope option is passed' do
+          it 'calls is_privilege_in_role?' do
+            expect(candy_pm.policy_machine_storage_adapter).to receive(:is_privilege_in_role?)
+            candy_pm.is_privilege_ignoring_prohibitions?(
+              frank,
+              create,
+              brie,
+              user_attribute_scope: cheese_engineer
+            )
+          end
+
+          it 'ignores prohibitions' do
+            expect(
+              candy_pm.is_privilege_ignoring_prohibitions?(
+                frank,
+                create,
+                brie,
+                user_attribute_scope: cheese_engineer
+              )
+            ).to be_truthy
+          end
+        end
+      end
+
       describe 'accessible_objects' do
         it 'returns objects accessible via a role' do
           expect(

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -169,9 +169,9 @@ describe 'ActiveRecord' do
               candy_pm.scoped_privileges(
                 frank,
                 brie,
-                user_attribute_scope: ice_cream_engineer
+                user_attribute_scope: employee
               )
-            ).to_not include([frank, create, brie])
+            ).to match_array([[frank, taste, brie]])
           end
         end
 


### PR DESCRIPTION
This PR updates several methods in the PM and adds a new one. These additions allow for consumers to scope various privilege-related things with a given user attribute context.

The new method is `is_privilege_in_role?`, which functions nearly the same as `is_privilege?` except it only returns true if the privilege is granted by the given user attribute or its descendants. 

The updates methods are `accessible_objects`, `accessible_ancestor_objects`, `accessible_operations`, and `scoped_privileges`. These now allow for an optional `:user_attribute_scope` entry in the options hash. These methods will only return results given by the specified user attribute scope or its descendants. 