### PR TITLE
[MCC-224756] Filter privileges by user attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.0
+* Add `is_privilege_with_filters?` method to ActiveRecord storage adapter.
+* Update `scoped_privileges`, `accessible_objects`, `accessible_ancestor_objects`, and `accessible_operations` to accept a user attribute filter.
+
 ## 1.8.0
 * Add accessible_ancestor_objects method to ActiveRecord storage adapter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.9.0
+* Add `is_privilege_with_filters?` and `is_privilege_ignoring_prohibitions_with_filters?` methods to Policy Machine.
 * Add `is_privilege_with_filters?` method to ActiveRecord storage adapter.
 * Update `scoped_privileges`, `accessible_objects`, `accessible_ancestor_objects`, and `accessible_operations` to accept a user attribute filter.
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -103,17 +103,7 @@ class PolicyMachine
   ##
   # Check the privilege with filters without checking for prohibitions.
   def is_filtered_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
-    unless user_or_attribute.is_a?(PM::User) || user_or_attribute.is_a?(PM::UserAttribute)
-      raise(ArgumentError, "user_attribute_pe must be a User or UserAttribute.")
-    end
-
-    unless [PM::Operation, Symbol, String].any? { |allowed_type| operation.is_a?(allowed_type) }
-      raise(ArgumentError, "operation must be an Operation, Symbol, or String.")
-    end
-
-    unless object_or_attribute.is_a?(PM::Object) || object_or_attribute.is_a?(PM::ObjectAttribute)
-      raise(ArgumentError, "object_or_attribute must either be an Object or ObjectAttribute.")
-    end
+    assert_privilege_parameters!(user_or_attribute, operation, object_or_attribute)
 
     if policy_machine_storage_adapter.respond_to?(:is_filtered_privilege?)
       policy_machine_storage_adapter.is_filtered_privilege?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options)
@@ -126,17 +116,7 @@ class PolicyMachine
   # Check the privilege without checking for prohibitions. May be called directly but is also used in is_privilege?
   #
   def is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options = {})
-    unless user_or_attribute.is_a?(PM::User) || user_or_attribute.is_a?(PM::UserAttribute)
-      raise(ArgumentError, "user_attribute_pe must be a User or UserAttribute.")
-    end
-
-    unless [PM::Operation, Symbol, String].any? { |allowed_type| operation.is_a?(allowed_type) }
-      raise(ArgumentError, "operation must be an Operation, Symbol, or String.")
-    end
-
-    unless object_or_attribute.is_a?(PM::Object) || object_or_attribute.is_a?(PM::ObjectAttribute)
-      raise(ArgumentError, "object_or_attribute must either be an Object or ObjectAttribute.")
-    end
+    assert_privilege_parameters!(user_or_attribute, operation, object_or_attribute)
 
     if options.empty? && policy_machine_storage_adapter.respond_to?(:is_privilege?)
       privilege = [user_or_attribute, operation, object_or_attribute].map { |obj| obj.respond_to?(:stored_pe) ? obj.stored_pe : obj }
@@ -386,6 +366,21 @@ class PolicyMachine
   end
 
   private
+
+  # Raise unless the given parameters are valid types
+  def assert_privilege_parameters!(user_or_attribute, operation, object_or_attribute)
+    unless user_or_attribute.is_a?(PM::User) || user_or_attribute.is_a?(PM::UserAttribute)
+      raise(ArgumentError, "user_attribute_pe must be a User or UserAttribute.")
+    end
+
+    unless [PM::Operation, Symbol, String].any? { |allowed_type| operation.is_a?(allowed_type) }
+      raise(ArgumentError, "operation must be an Operation, Symbol, or String.")
+    end
+
+    unless object_or_attribute.is_a?(PM::Object) || object_or_attribute.is_a?(PM::ObjectAttribute)
+      raise(ArgumentError, "object_or_attribute must either be an Object or ObjectAttribute.")
+    end
+  end
 
   # Retrieves all privileges and prohibitions for the given user or attribute on the object or attribute scope
   def get_all_scoped_privileges_and_prohibitions(user_or_attribute, object_or_attribute, options = {})

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -97,12 +97,12 @@ class PolicyMachine
   ##
   # Can we derive a privilege given a filtered set of user attributes?
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
-    is_filtered_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
+    is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
   end
 
   ##
   # Check the privilege with filters without checking for prohibitions.
-  def is_filtered_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
+  def is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     assert_privilege_parameters!(user_or_attribute, operation, object_or_attribute)
 
     if policy_machine_storage_adapter.respond_to?(:is_filtered_privilege?)

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -436,5 +436,4 @@ class PolicyMachine
       end
     end
   end
-
 end

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -94,10 +94,14 @@ class PolicyMachine
       (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
   end
 
+  ##
+  # Can we derive a privilege given a filtered set of user attributes?
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     is_filtered_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
   end
 
+  ##
+  # Check the privilege with filters without checking for prohibitions.
   def is_filtered_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     unless user_or_attribute.is_a?(PM::User) || user_or_attribute.is_a?(PM::UserAttribute)
       raise(ArgumentError, "user_attribute_pe must be a User or UserAttribute.")

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -97,7 +97,8 @@ class PolicyMachine
   ##
   # Can we derive a privilege given a set of filters?
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
-    is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
+    is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options) &&
+       (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
   end
 
   ##
@@ -105,11 +106,7 @@ class PolicyMachine
   def is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     assert_privilege_parameters!(user_or_attribute, operation, object_or_attribute)
 
-    if policy_machine_storage_adapter.respond_to?(:is_filtered_privilege?)
-      policy_machine_storage_adapter.is_filtered_privilege?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options)
-    else
-      raise(NotImplementedError, "is_filtered_privilege? not implemented in storage adapter #{policy_machine_storage_adapter.class}")
-    end
+    policy_machine_storage_adapter.is_filtered_privilege?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options)
   end
 
   ##

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -95,7 +95,7 @@ class PolicyMachine
   end
 
   ##
-  # Can we derive a privilege given a filtered set of user attributes?
+  # Can we derive a privilege given a set of filters?
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options) && (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
   end

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "1.8.0"
+  VERSION = "1.9.0"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -809,7 +809,7 @@ module PolicyMachineStorageAdapter
 
     # Gets the associations related to the given user or attribute or its descendants
     def associations_for_user_or_attribute(user_or_attribute, options)
-      user_attribute_filter = options.dig(:filters, :user_attributes)
+      user_attribute_filter = options[:filters][:user_attributes] if options[:filters] && options[:filters][:user_attributes]
 
       user_attribute_ids = user_or_attribute.descendants.where(user_attribute_filter).pluck(:id) | [user_or_attribute.id]
       PolicyElementAssociation.where(user_attribute_id: user_attribute_ids)

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -760,6 +760,8 @@ module PolicyMachineStorageAdapter
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation))
         candidates
       else
+        # Do not use the filter when checking prohibitions
+        preloaded_options = options.except(:filters).merge(ignore_prohibitions: true)
         candidates - accessible_objects(user_or_attribute, prohibition, options.merge(ignore_prohibitions: true))
       end
     end
@@ -787,7 +789,11 @@ module PolicyMachineStorageAdapter
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation))
         candidates
       else
-        preloaded_options = options.merge(ignore_prohibitions: true, ancestor_objects: ancestor_objects)
+        # Do not use the filter when checking prohibitions
+        preloaded_options = options.except(:filters).merge(ignore_prohibitions: true)
+        # If ancestor objects are filtered, preloaded ancestor objects cannot be used when checking prohibitions
+        preloaded_options.merge!(ancestor_objects: ancestor_objects) unless options[:filters]
+
         candidates - accessible_ancestor_objects(user_or_attribute, prohibition, root_object, preloaded_options)
       end
     end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -762,7 +762,7 @@ module PolicyMachineStorageAdapter
       else
         # Do not use the filter when checking prohibitions
         preloaded_options = options.except(:filters).merge(ignore_prohibitions: true)
-        candidates - accessible_objects(user_or_attribute, prohibition, preloaded_options))
+        candidates - accessible_objects(user_or_attribute, prohibition, preloaded_options)
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -719,7 +719,7 @@ module PolicyMachineStorageAdapter
       if policy_classes_containing_object.size < 2
         !accessible_operations(user_or_attribute, object_or_attribute, operation_id, filters: filters).empty?
       else
-        raise(NotImplementedError, 'is_filtered_privilege? does not support multiple policy classes!')
+        raise 'is_filtered_privilege? does not support multiple policy classes!'
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -709,6 +709,9 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    ## Optimized version of PolicyMachine#is_privilege_with_filters?
+    # Returns true if the user has the operation on the object, but only if the privilege
+    # can be derived via a user attribute that passes the filter
     def is_filtered_privilege?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
       policy_classes_containing_object = policy_classes_for_object_attribute(object_or_attribute)
       operation_id = operation.try(:unique_identifier) || operation.to_s

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -762,7 +762,7 @@ module PolicyMachineStorageAdapter
       else
         # Do not use the filter when checking prohibitions
         preloaded_options = options.except(:filters).merge(ignore_prohibitions: true)
-        candidates - accessible_objects(user_or_attribute, prohibition, options.merge(ignore_prohibitions: true))
+        candidates - accessible_objects(user_or_attribute, prohibition, preloaded_options))
       end
     end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -25,6 +25,316 @@ describe 'ActiveRecord' do
     it_behaves_like 'a policy machine storage adapter'
     let(:policy_machine_storage_adapter) { described_class.new }
 
+    describe 'scoping privileges by user attribute' do
+      let(:candy_pm) { PolicyMachine.new(name: 'Candy Machine', storage_adapter: PolicyMachineStorageAdapter::ActiveRecord)}
+
+      let(:frank) { candy_pm.create_user('frank') }
+      let(:employee) { candy_pm.create_user_attribute('employee', color: 'beige') }
+      let(:cheese_engineer) { candy_pm.create_user_attribute('cheese_engineer', color: 'purple') }
+      let(:ice_cream_engineer) { candy_pm.create_user_attribute('ice_cream_engineer', color: 'green') }
+
+      let(:chocolate) { candy_pm.create_object('chocolate') }
+      let(:vanilla) { candy_pm.create_object('vanilla') }
+      let(:french_vanilla) { candy_pm.create_object('french_vanilla') }
+      let(:american_vanilla) { candy_pm.create_object('american_vanilla') }
+      let(:ice_creams) { candy_pm.create_object_attribute('ice_creams') }
+
+      let(:brie) { candy_pm.create_object('brie') }
+      let(:swiss) { candy_pm.create_object('swiss') }
+      let(:cheeses) { candy_pm.create_object_attribute('cheeses') }
+
+      let(:money) { candy_pm.create_object('money') }
+      let(:finances) { candy_pm.create_object_attribute('finances') }
+
+      let(:products) { candy_pm.create_object_attribute('products') }
+
+      let(:business) { candy_pm.create_object_attribute('business') }
+
+      let(:taster) { candy_pm.create_operation_set('taster') }
+      let(:taste) { candy_pm.create_operation('taste') }
+
+      let(:creator) { candy_pm.create_operation_set('creator') }
+      let(:create) { candy_pm.create_operation('create') }
+
+      before do
+        # Frank is an engineer for cheese and ice cream
+        candy_pm.add_assignment(frank, cheese_engineer)
+        candy_pm.add_assignment(frank, ice_cream_engineer)
+        candy_pm.add_assignment(frank, employee)
+
+        # Engineers are employees
+        candy_pm.add_assignment(creator, taster)
+
+        # Establish the official ice creams and cheeses
+        candy_pm.add_assignment(chocolate, ice_creams)
+        candy_pm.add_assignment(vanilla, ice_creams)
+        candy_pm.add_assignment(french_vanilla, vanilla)
+        candy_pm.add_assignment(american_vanilla, vanilla)
+        candy_pm.add_assignment(brie, cheeses)
+        candy_pm.add_assignment(swiss, cheeses)
+
+        # Forbidden business things
+        candy_pm.add_assignment(money, finances)
+
+        # Cheeses and ice creams are products
+        candy_pm.add_assignment(ice_creams, products)
+        candy_pm.add_assignment(cheeses, products)
+
+        # Products and finances are part of business
+        candy_pm.add_assignment(products, business)
+        candy_pm.add_assignment(finances, business)
+
+        # Creators create, tasters taste
+        candy_pm.add_assignment(creator, create)
+        candy_pm.add_assignment(taster, taste)
+
+        # Engineers can create, employees can taste products
+        candy_pm.add_association(employee, taster, products)
+        candy_pm.add_association(cheese_engineer, creator, cheeses)
+        candy_pm.add_association(ice_cream_engineer, creator, ice_creams)
+      end
+
+      describe 'is_privilege_with_filters?' do
+        context 'when the user has access via a filtered user attribute' do
+          it 'returns true' do
+            filters = {
+              color: 'purple'
+            }
+
+            expect(
+              candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
+            ).to be true
+          end
+
+          context 'and a prohibition is set' do
+            let(:cant_create) { candy_pm.create_operation_set('cant_create') }
+
+            before do
+              candy_pm.add_assignment(cant_create, create.prohibition)
+              candy_pm.add_association(cheese_engineer, cant_create, brie)
+            end
+
+            it 'returns false' do
+              filters = {
+                color: 'purple'
+              }
+
+              expect(
+                candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
+              ).to be false
+            end
+          end
+        end
+
+        context 'when the user has access via cascading operation sets assigned to the user attribute' do
+          let(:money_handling) { candy_pm.create_operation_set('money_handling') }
+
+          before do
+            candy_pm.add_assignment(money_handling, creator)
+            candy_pm.add_association(cheese_engineer, money_handling, finances)
+          end
+
+          it 'returns true' do
+            filters = { color: 'purple' }
+
+            expect(
+              candy_pm.is_privilege_with_filters?(frank, create, money, filters: filters)
+            ).to be true
+          end
+        end
+
+        context 'when the user has access via a user attribute that is filtered out' do
+          it 'returns false' do
+            filters = { color: 'beige' }
+
+            expect(
+              candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
+            ).to be false
+          end
+        end
+
+        context 'when the user does not have access via any user attribute' do
+          it 'returns false' do
+            filters = { color: 'purple' }
+
+            expect(
+              candy_pm.is_privilege_with_filters?(frank, create, money, filters: filters)
+            ).to be false
+          end
+        end
+      end
+
+      describe 'scoped_privileges' do
+        context 'when the user has access via a filtered user attribute' do
+          it 'returns all the privileges granted by that attribute' do
+            expect(
+              candy_pm.scoped_privileges(
+                frank,
+                brie,
+                filters: { color: 'purple' }
+              )
+            ).to contain_exactly([frank, create, brie], [frank, taste, brie])
+          end
+
+          context 'when there is a prohibition' do
+            let(:cant_create) { candy_pm.create_operation_set('cant_create') }
+
+            before do
+              candy_pm.add_assignment(cant_create, create.prohibition)
+              candy_pm.add_association(employee, cant_create, brie)
+            end
+
+            it 'does not return the prohibited privilege' do
+              expect(
+                candy_pm.scoped_privileges(
+                  frank,
+                  brie,
+                  filters: { color: 'purple' }
+                )
+              ).to contain_exactly([frank, taste, brie])
+            end
+          end
+        end
+
+        context 'when the user has access via a user attribute that is filtered out' do
+          it 'does not return the privilege given by the other user attribute' do
+            expect(
+              candy_pm.scoped_privileges(
+                frank,
+                brie,
+                filters: { color: 'beige' }
+              )
+            ).to match_array([[frank, taste, brie]])
+          end
+        end
+
+        context 'when the user does not have access via any user attribute' do
+          it 'returns an empty array' do
+            expect(
+              candy_pm.scoped_privileges(
+                frank,
+                money,
+                filters: { color: 'purple' }
+              )
+            ).to be_empty
+          end
+        end
+      end
+
+      describe 'is_privilege_ignoring_prohibitions?' do
+        let(:cant_create) { candy_pm.create_operation_set('cant_create') }
+
+        before do
+          candy_pm.add_assignment(cant_create, create.prohibition)
+          candy_pm.add_association(cheese_engineer, cant_create, brie)
+        end
+
+        context 'when a filter is passed' do
+          it 'calls is_privilege_with_filters?' do
+            expect(candy_pm.policy_machine_storage_adapter).to receive(:is_privilege_with_filters?)
+            candy_pm.is_privilege_ignoring_prohibitions?(
+              frank,
+              create,
+              brie,
+              filters: { color: 'purple' }
+            )
+          end
+
+          it 'ignores prohibitions' do
+            expect(
+              candy_pm.is_privilege_ignoring_prohibitions?(
+                frank,
+                create,
+                brie,
+                filters: { color: 'purple' }
+              )
+            ).to be_truthy
+          end
+        end
+      end
+
+      describe 'accessible_objects' do
+        it 'returns objects accessible via the filtered attribute' do
+          expect(
+            candy_pm.accessible_objects(
+              frank,
+              create,
+              filters: { color: 'purple' },
+              key: :unique_identifier
+            ).map(&:unique_identifier)
+          ).to match_array(['brie', 'swiss'])
+        end
+
+        it 'does not return objects that are not accessible via the filtered attribute' do
+          expect(
+            candy_pm.accessible_objects(frank, create, filters: { color: 'beige' })
+          ).to be_empty
+        end
+
+        context 'prohibitions' do
+          let(:cant_create) { candy_pm.create_operation_set('cant_create') }
+
+          before do
+            candy_pm.add_assignment(cant_create, create.prohibition)
+            candy_pm.add_association(cheese_engineer, cant_create, brie)
+          end
+
+          it 'does not return objects with prohibitions' do
+            expect(
+              candy_pm.accessible_objects(
+                frank,
+                create,
+                filters: { color: 'purple' },
+                key: :unique_identifier
+              ).map(&:unique_identifier)
+            ).to_not include('brie')
+          end
+        end
+      end
+
+      describe 'accessible_ancestor_objects' do
+        it 'returns objects accessible via the filtered attribute on an object scope' do
+          expect(
+            candy_pm.accessible_ancestor_objects(
+              frank,
+              create,
+              vanilla,
+              filters: { color: 'green' },
+              key: :unique_identifier
+            ).map(&:unique_identifier)
+          ).to match_array(['vanilla', 'french_vanilla', 'american_vanilla'])
+        end
+
+        it 'does not return objects that are not accessible via the filtered attribute on an object scope' do
+          expect(
+            candy_pm.accessible_ancestor_objects(frank, create, vanilla, filters: { color: 'beige' })
+          ).to be_empty
+        end
+
+        context 'prohibitions' do
+          let(:cant_create) { candy_pm.create_operation_set('cant_create') }
+
+          before do
+            candy_pm.add_assignment(cant_create, create.prohibition)
+            candy_pm.add_association(ice_cream_engineer, cant_create, french_vanilla)
+          end
+
+         it 'does not return objects with prohibitions' do
+           expect(
+             candy_pm.accessible_ancestor_objects(
+               frank,
+               create,
+               vanilla,
+               filters: { color: 'green' },
+               key: :unique_identifier
+             ).map(&:unique_identifier)
+           ).to_not include('french_vanilla')
+          end
+        end
+      end
+    end
+
+
     describe 'find_all_of_type' do
       let(:pm_uuid) { SecureRandom.uuid }
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -143,6 +143,24 @@ describe 'ActiveRecord' do
           end
         end
 
+        # Support for cascading user attribute assignments is not yet supported
+        context 'when the user has access via cascading user attributes' do
+          let(:money_handler) { candy_pm.create_user_attribute('money_handler') }
+
+          before do
+            candy_pm.add_assignment(money_handler, cheese_engineer)
+            candy_pm.add_association(money_handler, creator, money)
+          end
+
+          it 'returns false' do
+            filters = { color: 'purple' }
+
+            expect(
+              candy_pm.is_privilege_with_filters?(frank, create, money, filters: filters)
+            ).to be false
+          end
+        end
+
         context 'when the user has access via a user attribute that is filtered out' do
           it 'returns false' do
             filters = { color: 'beige' }

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -97,9 +97,7 @@ describe 'ActiveRecord' do
       describe 'is_privilege_with_filters?' do
         context 'when the user has access via a filtered user attribute' do
           it 'returns true' do
-            filters = {
-              color: 'purple'
-            }
+            filters = { color: 'purple' }
 
             expect(
               candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
@@ -115,9 +113,7 @@ describe 'ActiveRecord' do
             end
 
             it 'returns false' do
-              filters = {
-                color: 'purple'
-              }
+              filters = { color: 'purple' }
 
               expect(
                 candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
@@ -185,12 +181,10 @@ describe 'ActiveRecord' do
       describe 'scoped_privileges' do
         context 'when the user has access via a filtered user attribute' do
           it 'returns all the privileges granted by that attribute' do
+            filters = { color: 'purple' }
+
             expect(
-              candy_pm.scoped_privileges(
-                frank,
-                brie,
-                filters: { color: 'purple' }
-              )
+              candy_pm.scoped_privileges(frank, brie, filters: filters)
             ).to contain_exactly([frank, create, brie], [frank, taste, brie])
           end
 
@@ -203,12 +197,10 @@ describe 'ActiveRecord' do
             end
 
             it 'does not return the prohibited privilege' do
+              filters = { color: 'purple' }
+
               expect(
-                candy_pm.scoped_privileges(
-                  frank,
-                  brie,
-                  filters: { color: 'purple' }
-                )
+                candy_pm.scoped_privileges(frank, brie, filters: filters)
               ).to contain_exactly([frank, taste, brie])
             end
           end
@@ -216,24 +208,20 @@ describe 'ActiveRecord' do
 
         context 'when the user has access via a user attribute that is filtered out' do
           it 'does not return the privilege given by the other user attribute' do
+            filters = { color: 'beige' }
+
             expect(
-              candy_pm.scoped_privileges(
-                frank,
-                brie,
-                filters: { color: 'beige' }
-              )
+              candy_pm.scoped_privileges(frank, brie, filters: filters)
             ).to match_array([[frank, taste, brie]])
           end
         end
 
         context 'when the user does not have access via any user attribute' do
           it 'returns an empty array' do
+            filters = { color: 'purple' }
+
             expect(
-              candy_pm.scoped_privileges(
-                frank,
-                money,
-                filters: { color: 'purple' }
-              )
+              candy_pm.scoped_privileges(frank, money, filters: filters)
             ).to be_empty
           end
         end
@@ -250,42 +238,40 @@ describe 'ActiveRecord' do
         context 'when a filter is passed' do
           it 'calls is_privilege_with_filters?' do
             expect(candy_pm.policy_machine_storage_adapter).to receive(:is_privilege_with_filters?)
-            candy_pm.is_privilege_ignoring_prohibitions?(
-              frank,
-              create,
-              brie,
-              filters: { color: 'purple' }
-            )
+
+            filters = { color: 'purple' }
+            candy_pm.is_privilege_ignoring_prohibitions?(frank, create, brie, filters: filters)
           end
 
           it 'ignores prohibitions' do
+            filters = { color: 'purple' }
+
             expect(
-              candy_pm.is_privilege_ignoring_prohibitions?(
-                frank,
-                create,
-                brie,
-                filters: { color: 'purple' }
-              )
-            ).to be_truthy
+              candy_pm.is_privilege_ignoring_prohibitions?(frank, create, brie, filters: filters)
+            ).to be true
           end
         end
       end
 
       describe 'accessible_objects' do
         it 'returns objects accessible via the filtered attribute' do
+          filters = { color: 'purple' }
+
           expect(
             candy_pm.accessible_objects(
               frank,
               create,
-              filters: { color: 'purple' },
+              filters: filters,
               key: :unique_identifier
             ).map(&:unique_identifier)
           ).to match_array(['brie', 'swiss'])
         end
 
         it 'does not return objects that are not accessible via the filtered attribute' do
+          filters = { color: 'beige' }
+
           expect(
-            candy_pm.accessible_objects(frank, create, filters: { color: 'beige' })
+            candy_pm.accessible_objects(frank, create, filters: filters)
           ).to be_empty
         end
 
@@ -298,11 +284,13 @@ describe 'ActiveRecord' do
           end
 
           it 'does not return objects with prohibitions' do
+            filters = { color: 'purple' }
+
             expect(
               candy_pm.accessible_objects(
                 frank,
                 create,
-                filters: { color: 'purple' },
+                filters: filters,
                 key: :unique_identifier
               ).map(&:unique_identifier)
             ).to_not include('brie')
@@ -312,20 +300,24 @@ describe 'ActiveRecord' do
 
       describe 'accessible_ancestor_objects' do
         it 'returns objects accessible via the filtered attribute on an object scope' do
+          filters = { color: 'green' }
+
           expect(
             candy_pm.accessible_ancestor_objects(
               frank,
               create,
               vanilla,
-              filters: { color: 'green' },
+              filters: filters,
               key: :unique_identifier
             ).map(&:unique_identifier)
           ).to match_array(['vanilla', 'french_vanilla', 'american_vanilla'])
         end
 
         it 'does not return objects that are not accessible via the filtered attribute on an object scope' do
+          filters = { color: 'beige' }
+
           expect(
-            candy_pm.accessible_ancestor_objects(frank, create, vanilla, filters: { color: 'beige' })
+            candy_pm.accessible_ancestor_objects(frank, create, vanilla, filters: filters)
           ).to be_empty
         end
 
@@ -338,12 +330,14 @@ describe 'ActiveRecord' do
           end
 
          it 'does not return objects with prohibitions' do
+           filters = { color: 'green' }
+
            expect(
              candy_pm.accessible_ancestor_objects(
                frank,
                create,
                vanilla,
-               filters: { color: 'green' },
+               filters: filters,
                key: :unique_identifier
              ).map(&:unique_identifier)
            ).to_not include('french_vanilla')

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -97,7 +97,7 @@ describe 'ActiveRecord' do
       describe 'is_privilege_with_filters?' do
         context 'when the user has access via a filtered user attribute' do
           it 'returns true' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
@@ -113,7 +113,7 @@ describe 'ActiveRecord' do
             end
 
             it 'returns false' do
-              filters = { color: 'purple' }
+              filters = { user_attributes: { color: 'purple' } }
 
               expect(
                 candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
@@ -131,7 +131,7 @@ describe 'ActiveRecord' do
           end
 
           it 'returns true' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.is_privilege_with_filters?(frank, create, money, filters: filters)
@@ -149,7 +149,7 @@ describe 'ActiveRecord' do
           end
 
           it 'returns false' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.is_privilege_with_filters?(frank, create, money, filters: filters)
@@ -159,7 +159,7 @@ describe 'ActiveRecord' do
 
         context 'when the user has access via a user attribute that is filtered out' do
           it 'returns false' do
-            filters = { color: 'beige' }
+            filters = { user_attributes: { color: 'beige' } }
 
             expect(
               candy_pm.is_privilege_with_filters?(frank, create, brie, filters: filters)
@@ -169,7 +169,7 @@ describe 'ActiveRecord' do
 
         context 'when the user does not have access via any user attribute' do
           it 'returns false' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.is_privilege_with_filters?(frank, create, money, filters: filters)
@@ -181,7 +181,7 @@ describe 'ActiveRecord' do
       describe 'scoped_privileges' do
         context 'when the user has access via a filtered user attribute' do
           it 'returns all the privileges granted by that attribute' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.scoped_privileges(frank, brie, filters: filters)
@@ -197,7 +197,7 @@ describe 'ActiveRecord' do
             end
 
             it 'does not return the prohibited privilege' do
-              filters = { color: 'purple' }
+              filters = { user_attributes: { color: 'purple' } }
 
               expect(
                 candy_pm.scoped_privileges(frank, brie, filters: filters)
@@ -208,7 +208,7 @@ describe 'ActiveRecord' do
 
         context 'when the user has access via a user attribute that is filtered out' do
           it 'does not return the privilege given by the other user attribute' do
-            filters = { color: 'beige' }
+            filters = { user_attributes: { color: 'beige' } }
 
             expect(
               candy_pm.scoped_privileges(frank, brie, filters: filters)
@@ -218,7 +218,7 @@ describe 'ActiveRecord' do
 
         context 'when the user does not have access via any user attribute' do
           it 'returns an empty array' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.scoped_privileges(frank, money, filters: filters)
@@ -239,12 +239,12 @@ describe 'ActiveRecord' do
           it 'calls is_privilege_with_filters?' do
             expect(candy_pm.policy_machine_storage_adapter).to receive(:is_privilege_with_filters?)
 
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
             candy_pm.is_privilege_ignoring_prohibitions?(frank, create, brie, filters: filters)
           end
 
           it 'ignores prohibitions' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.is_privilege_ignoring_prohibitions?(frank, create, brie, filters: filters)
@@ -255,7 +255,7 @@ describe 'ActiveRecord' do
 
       describe 'accessible_objects' do
         it 'returns objects accessible via the filtered attribute' do
-          filters = { color: 'purple' }
+          filters = { user_attributes: { color: 'purple' } }
 
           expect(
             candy_pm.accessible_objects(
@@ -268,7 +268,7 @@ describe 'ActiveRecord' do
         end
 
         it 'does not return objects that are not accessible via the filtered attribute' do
-          filters = { color: 'beige' }
+          filters = { user_attributes: { color: 'beige' } }
 
           expect(
             candy_pm.accessible_objects(frank, create, filters: filters)
@@ -284,7 +284,7 @@ describe 'ActiveRecord' do
           end
 
           it 'does not return objects with prohibitions' do
-            filters = { color: 'purple' }
+            filters = { user_attributes: { color: 'purple' } }
 
             expect(
               candy_pm.accessible_objects(
@@ -300,7 +300,7 @@ describe 'ActiveRecord' do
 
       describe 'accessible_ancestor_objects' do
         it 'returns objects accessible via the filtered attribute on an object scope' do
-          filters = { color: 'green' }
+          filters = { user_attributes: { color: 'green' } }
 
           expect(
             candy_pm.accessible_ancestor_objects(
@@ -314,7 +314,7 @@ describe 'ActiveRecord' do
         end
 
         it 'does not return objects that are not accessible via the filtered attribute on an object scope' do
-          filters = { color: 'beige' }
+          filters = { user_attributes: { color: 'beige' } }
 
           expect(
             candy_pm.accessible_ancestor_objects(frank, create, vanilla, filters: filters)
@@ -330,7 +330,7 @@ describe 'ActiveRecord' do
           end
 
          it 'does not return objects with prohibitions' do
-           filters = { color: 'green' }
+           filters = { user_attributes: { color: 'green' } }
 
            expect(
              candy_pm.accessible_ancestor_objects(


### PR DESCRIPTION
This PR updates the Policy Machine to allow filtering privilege APIs so they only return privileges (or whether a privilege exists) if it is derived via a user attribute that passes the filter.