### PR TITLE
[MCC-229209 Fix JSON serialization of the extra_attributes column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+* Fix JSON serialization of the `extra_attributes` column.
+
 ## 2.0.0
 * Upgrade the Policy Machine to support Rails 5.2.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -240,6 +240,7 @@ module PolicyMachineStorageAdapter
       end
 
       def self.serialize(store:, name:, serializer: nil)
+        # Use the passed serializer if present, otherwise use Rails' default serialization
         active_record_serialize store, serializer if serializer
 
         store_accessor store, name

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -95,16 +95,6 @@ module PolicyMachineStorageAdapter
       true #TODO: More useful return value?
     end
 
-    class HashSerializer
-      def self.dump(hash)
-        hash.to_json
-      end
-
-      def self.load(hash)
-        hash.is_a?(String) ? JSON.parse(hash) : hash || {}
-      end
-    end
-
     class ApplicationRecord < ::ActiveRecord::Base
       require 'will_paginate/active_record'
       self.abstract_class = true
@@ -127,7 +117,7 @@ module PolicyMachineStorageAdapter
 
       attr_accessor :extra_attributes_hash
 
-      active_record_serialize :extra_attributes, HashSerializer
+      active_record_serialize :extra_attributes, JSON
 
       def method_missing(meth, *args, &block)
         store_attributes
@@ -250,7 +240,7 @@ module PolicyMachineStorageAdapter
       end
 
       def self.serialize(store:, name:, serializer: nil)
-        active_record_serialize store, serializer
+        active_record_serialize store, serializer if serializer
 
         store_accessor store, name
       end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -1541,6 +1541,7 @@ describe 'ActiveRecord' do
             it 'can specify a root store level store supported by the backing system' do
               some_hash = { 'foo' => 'bar' }
               obj = policy_machine.send("create_#{type}", SecureRandom.uuid, { document: some_hash })
+
               expect(obj.stored_pe.document).to eq some_hash
               expect(obj.stored_pe.extra_attributes).to be_empty
             end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -1533,7 +1533,7 @@ describe 'ActiveRecord' do
       describe '.serialize' do
         before(:all) do
           klass = PolicyMachineStorageAdapter::ActiveRecord::PolicyElement
-          klass.serialize(store: :document, name: :is_arbitrary, serializer: JSON)
+          klass.serialize(store: :document, name: :is_arbitrary)
         end
 
         (PolicyMachine::POLICY_ELEMENT_TYPES).each do |type|
@@ -1541,7 +1541,6 @@ describe 'ActiveRecord' do
             it 'can specify a root store level store supported by the backing system' do
               some_hash = { 'foo' => 'bar' }
               obj = policy_machine.send("create_#{type}", SecureRandom.uuid, { document: some_hash })
-
               expect(obj.stored_pe.document).to eq some_hash
               expect(obj.stored_pe.extra_attributes).to be_empty
             end
@@ -1553,6 +1552,16 @@ describe 'ActiveRecord' do
               expect(obj.stored_pe.is_arbitrary).to eq pm2_hash['is_arbitrary']
               expect(obj.stored_pe.document).to eq pm2_hash
               expect(obj.stored_pe.extra_attributes).to be_empty
+            end
+
+            it 'stores a JSON representation of an empty hash by default' do
+              obj = policy_machine.send("create_#{type}", SecureRandom.uuid)
+
+              sql = "SELECT extra_attributes FROM policy_elements WHERE id = #{obj.id}"
+              result = ActiveRecord::Base.connection.execute(sql)
+              database_entry = result[0]["extra_attributes"]
+
+              expect(database_entry).to eq('{}')
             end
           end
         end


### PR DESCRIPTION
This PR fixes the JSON serialization of the `extra_attributes` column in the ActiveRecord adapter's PolicyElement class.

Previously, empty `extra_attributes` entries were stored as `null` values. Now, they'll properly be JSON representations of empty hashes. 

@mdsol/team04 - please review 