### PR TITLE
[MCC-468035] Move associations_filtered_by_operation to public visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.0
+* Elevate associations_filtered_by_operation to a public method in the ActiveRecord storage adapter.
+
 ## 2.0.1
 * Fix JSON serialization of the `extra_attributes` column.
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -291,6 +291,15 @@ class PolicyMachine
     end
   end
 
+  def associations_filtered_by_operation(associations, operation)
+    if policy_machine_storage_adapter.respond_to?(:associations_filtered_by_operation)
+      policy_machine_storage_adapter.associations_filtered_by_operation(associations, operation)
+    else
+      raise NoMethodError, "associations_filtered_by_operation is not implemented for storage adapter " \
+                           "#{policy_machine_storage_adapter.class}."
+    end
+  end
+
   ##
   # Returns an array of all user_attributes a PM::User is assigned to,
   # directly or indirectly.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -804,6 +804,17 @@ module PolicyMachineStorageAdapter
       end
     end
 
+    # Filters a list of associations to those related to a given operation
+    def associations_filtered_by_operation(associations, operation)
+      operation_id = operation.try(:unique_identifier) || operation.to_s
+
+      operation_set_ids = associations.pluck(:operation_set_id)
+
+      filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
+
+      associations.where(operation_set_id: filtered_operation_set_ids)
+    end
+
     private
 
     # Returns an array of all the objects accessible for a given user or attribute and operation
@@ -819,17 +830,6 @@ module PolicyMachineStorageAdapter
 
       user_attribute_ids = user_or_attribute.descendants.where(user_attribute_filter).pluck(:id) | [user_or_attribute.id]
       PolicyElementAssociation.where(user_attribute_id: user_attribute_ids)
-    end
-
-    # Filters a list of associations to those related to a given operation
-    def associations_filtered_by_operation(associations, operation)
-      operation_id = operation.try(:unique_identifier) || operation.to_s
-
-      operation_set_ids = associations.pluck(:operation_set_id)
-
-      filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
-
-      associations.where(operation_set_id: filtered_operation_set_ids)
     end
 
     # Builds an array of PolicyElement objects within the scope of a given

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -808,11 +808,13 @@ module PolicyMachineStorageAdapter
     def associations_filtered_by_operation(associations, operation)
       operation_id = operation.try(:unique_identifier) || operation.to_s
 
-      operation_set_ids = associations.pluck(:operation_set_id)
-
-      filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
-
-      associations.where(operation_set_id: filtered_operation_set_ids)
+      if associations.present?
+        operation_set_ids = associations.pluck(:operation_set_id)
+        filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
+        associations.where(operation_set_id: filtered_operation_set_ids)
+      else
+        []
+      end
     end
 
     private


### PR DESCRIPTION
This PR moves the method `associations_filtered_by_operation` to public visibility in the ActiveRecord storage adapter. This method allows policy element associations to be filtered to just those containing the specified operation.