### PR TITLE
[MCC-468036] Add include_prohibitions filter to #scoped_privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1
+* Added `include_prohibitions` option to PolicyMachine #scoped_privileges.
+
 ## 2.1.0
 * Elevate associations_filtered_by_operation to a public method in the ActiveRecord storage adapter.
 

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -222,6 +222,8 @@ class PolicyMachine
 
     if options[:ignore_prohibitions]
       privileges
+    elsif options[:include_prohibitions]
+      prohibitions + privileges
     else
       prohibited_operations = prohibitions.map { |_,prohibition,_| prohibition.operation }
       privileges.reject { |_,op,_| prohibited_operations.include?(op.unique_identifier) }

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -203,7 +203,7 @@ class PolicyMachine
   # policy machine for the given user (attribute) on the given
   # object (attribute).
   #
-  # TODO:  might make privilege a class of its own
+  # TODO: might make privilege a class of its own
   def scoped_privileges(user_or_attribute, object_or_attribute, options = {})
     # Get an initial set of privileges and prohibitions without filtering. Prohibition checks should be
     # filter-agnostic since prohibitions are meant to be blocking.
@@ -223,7 +223,7 @@ class PolicyMachine
     if options[:ignore_prohibitions]
       privileges
     elsif options[:include_prohibitions]
-      prohibitions + privileges
+      privileges | prohibitions
     else
       prohibited_operations = prohibitions.map { |_,prohibition,_| prohibition.operation }
       privileges.reject { |_,op,_| prohibited_operations.include?(op.unique_identifier) }

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1260,23 +1260,24 @@ shared_examples "a policy machine" do
 
       context 'when the user only has prohibitions' do
         let(:all_prohibitions) { policy_machine.create_operation_set('all_prohibitions') }
+        let!(:ua_2) { policy_machine.create_user_attribute('ua_2') }
 
         before do
           policy_machine.add_assignment(all_prohibitions, prohib_read)
           policy_machine.add_assignment(all_prohibitions, prohib_write)
           policy_machine.add_assignment(all_prohibitions, prohib_edit)
 
-          policy_machine.add_association(ua, all_prohibitions, one_fish)
+          policy_machine.add_association(ua_2, all_prohibitions, one_fish)
         end
 
         it 'returns all privileges and prohibitions the user has on the specified object' do
           expected_privs_and_prohibs = [
-            [user, prohib_read, one_fish],
-            [user, prohib_write, one_fish],
-            [user, prohib_edit, one_fish]
+            [ua_2, prohib_read, one_fish],
+            [ua_2, prohib_write, one_fish],
+            [ua_2, prohib_edit, one_fish]
           ]
 
-          expect(policy_machine.scoped_privileges(user, one_fish, options)).to match_array(expected_privs_and_prohibs)
+          expect(policy_machine.scoped_privileges(ua_2, one_fish, options)).to match_array(expected_privs_and_prohibs)
         end
       end
     end

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1065,7 +1065,6 @@ shared_examples "a policy machine" do
   end
 
   describe 'accessible_objects' do
-
     before do
       @one_fish = policy_machine.create_object('one:fish')
       @two_fish = policy_machine.create_object('two:fish')
@@ -1135,14 +1134,116 @@ shared_examples "a policy machine" do
       it 'can ignore prohibitions' do
         expect( policy_machine.accessible_objects(@u1, @read, ignore_prohibitions: true).map(&:unique_identifier) ).to match_array(['one:fish', 'two:fish','red:one'])
       end
-
     end
-
   end
 
+  describe '#scoped_privileges' do
+    let!(:one_fish) { policy_machine.create_object('one:fish') }
+    let!(:two_fish) { policy_machine.create_object('two:fish') }
+    let!(:red_one) { policy_machine.create_object('red:one') }
+    let!(:blue_one) { policy_machine.create_object('blue:one') }
+    let!(:reader) { policy_machine.create_operation_set('reader') }
+    let!(:read) { policy_machine.create_operation('read') }
+    let!(:writer) { policy_machine.create_operation_set('writer') }
+    let!(:write) { policy_machine.create_operation('write') }
+    let!(:prohib_write) { write.prohibition }
+    let!(:prohib_edit) { edit.prohibition }
+    let!(:edit) { policy_machine.create_operation('edit') }
+    let!(:user) { policy_machine.create_user('u1') }
+    let!(:ua) { policy_machine.create_user_attribute('ua') }
+    let!(:oa) { policy_machine.create_object_attribute('oa') }
+
+    before do
+
+      [one_fish, two_fish, red_one].each do |object|
+        policy_machine.add_association(ua, writer, object)
+      end
+
+      policy_machine.add_assignment(reader, read)
+      policy_machine.add_assignment(reader, write)
+      policy_machine.add_assignment(reader, edit)
+      policy_machine.add_assignment(reader, prohib_write)
+      policy_machine.add_assignment(reader, prohib_edit)
+      policy_machine.add_assignment(writer, read)
+      policy_machine.add_assignment(writer, write)
+      policy_machine.add_assignment(writer, edit)
+      policy_machine.add_assignment(writer, prohib_edit)
+
+      policy_machine.add_assignment(user, ua)
+      policy_machine.add_assignment(red_one, oa)
+      policy_machine.add_assignment(blue_one, oa)
+
+      policy_machine.add_association(ua, reader, oa)
+    end
+
+    context "when no options are provided" do
+      it 'returns all privileges the user has on the specified object' do
+        expected_privileges = [
+          [user, read, one_fish],
+          [user, write, one_fish]
+        ]
+
+        expect(policy_machine.scoped_privileges(user, one_fish)).to match_array(expected_privileges)
+      end
+
+      it 'returns all privileges the user has on the specified object attribute' do
+        expected_privileges = [
+          [user, read, oa]
+        ]
+
+        expect(policy_machine.scoped_privileges(user, oa)).to match_array(expected_privileges)
+      end
+
+      it 'does not returned prohibited privileges' do
+        unexpected_privilege = [user, edit, one_fish]
+        expect(policy_machine.scoped_privileges(user, one_fish)).not_to include(unexpected_privilege)
+      end
+    end
+
+    context "when the 'filters' option is provided" do
+      let(:options) { { user_attributes: { unique_identifier: writer.unique_identifier } } }
+
+      it 'returns all privileges the user has on the specified object with filters applied' do
+        expected_privileges = [
+          [user, read, one_fish],
+          [user, write, one_fish]
+        ]
+
+        expect(policy_machine.scoped_privileges(user, one_fish, options)).to match_array(expected_privileges)
+      end
+    end
+
+    context "when the 'ignore_prohibitions' option is provided" do
+      let(:options) { { ignore_prohibitions: true } }
+
+      it 'returns all privileges the user has on the specified object ignoring prohibitions' do
+        expected_privileges = [
+          [user, read, one_fish],
+          [user, write, one_fish],
+          [user, edit, one_fish]
+        ]
+
+        expect(policy_machine.scoped_privileges(user, one_fish, options)).to match_array(expected_privileges)
+      end
+    end
+
+    context "when the 'include_prohibitions' option is provided" do
+      let(:options) { { include_prohibitions: true } }
+
+      it 'returns all privileges and prohibitions the user has on the specified object' do
+        expected_privs_and_prohibs = [
+          [user, read, one_fish],
+          [user, write, one_fish],
+          [user, edit, one_fish],
+          [user, prohib_edit, one_fish]
+        ]
+
+        expect(policy_machine.scoped_privileges(user, one_fish, options)).to match_array(expected_privs_and_prohibs)
+      end
+    end
+  end
 
   describe 'batch_find' do
-
     before do
       @one_fish = policy_machine.create_object('one:fish')
       @two_fish = policy_machine.create_object('two:fish')

--- a/spec/support/shared_examples_policy_machine.rb
+++ b/spec/support/shared_examples_policy_machine.rb
@@ -1212,6 +1212,20 @@ shared_examples "a policy machine" do
 
         expect(policy_machine.scoped_privileges(user, one_fish, options)).to match_array(expected_privileges)
       end
+
+      it 'does not returned prohibited privileges applied outside of the filters' do
+        oa_parent = policy_machine.create_object_attribute('oa_parent')
+        policy_machine.add_assignment(oa, oa_parent)
+
+        prohib_writer = policy_machine.create_operation_set('prohib_writer')
+        policy_machine.add_assignment(prohib_writer, prohib_write)
+
+        policy_machine.add_association(ua, writer, oa)
+        policy_machine.add_association(ua, prohib_writer, oa_parent)
+
+        prohibition = [user, write, oa]
+        expect(policy_machine.scoped_privileges(user, oa, options)).not_to include(prohibition)
+      end
     end
 
     context "when the 'ignore_prohibitions' option is provided" do


### PR DESCRIPTION
This PR adds an `include_prohibitions` option to the `#scoped_privileges` method in the PolicyMachine. This option returns all prohibitions the user (attribute) has on the specified object (attribute) alongside their derived privileges.

