### PR TITLE
[MCC-488586] Optimize accessible ancestor objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 2.1.2
+* Optimized ActiveRecord adapter for PolicyMachine `#accessible_ancestor_objects`.
+
 ## 2.1.1
-* Added `include_prohibitions` option to PolicyMachine #scoped_privileges.
+* Added `include_prohibitions` option to PolicyMachine `#scoped_privileges`.
 
 ## 2.1.0
 * Elevate associations_filtered_by_operation to a public method in the ActiveRecord storage adapter.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -783,7 +783,7 @@ module PolicyMachineStorageAdapter
       associations = associations_for_user_or_attribute(user_or_attribute, options)
       filtered_associations = associations_filtered_by_operation(associations, operation)
 
-      candidates = PolicyElementAssociation.all_accessible_objects(
+      candidates = PolicyElementAssociation.scoped_accessible_objects(
         filtered_associations,
         root_id: root_object_id,
         filters: { type: class_for_type('object').name }

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -783,17 +783,11 @@ module PolicyMachineStorageAdapter
       associations = associations_for_user_or_attribute(user_or_attribute, options)
       filtered_associations = associations_filtered_by_operation(associations, operation)
 
-      shortcircuit_ancestors = options[:filters].nil? && is_privilege?(user_or_attribute, operation, root_object)
-      candidates = if shortcircuit_ancestors
-                     ancestors = Assignment.ancestors_of(root_object)
-                     ancestors.or(PolicyElement.where(id: root_object_id))
-                   else
-                     PolicyElementAssociation.all_accessible_objects(
+      candidates = PolicyElementAssociation.all_accessible_objects(
                        filtered_associations,
                        root_id: root_object_id,
                        filters: { type: class_for_type('object').name }
                      )
-                   end
 
       inclusion = options[:includes]
       if inclusion

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -784,10 +784,10 @@ module PolicyMachineStorageAdapter
       filtered_associations = associations_filtered_by_operation(associations, operation)
 
       candidates = PolicyElementAssociation.all_accessible_objects(
-                       filtered_associations,
-                       root_id: root_object_id,
-                       filters: { type: class_for_type('object').name }
-                     )
+        filtered_associations,
+        root_id: root_object_id,
+        filters: { type: class_for_type('object').name }
+      )
 
       inclusion = options[:includes]
       if inclusion

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -783,11 +783,17 @@ module PolicyMachineStorageAdapter
       associations = associations_for_user_or_attribute(user_or_attribute, options)
       filtered_associations = associations_filtered_by_operation(associations, operation)
 
-      candidates = PolicyElementAssociation.all_accessible_objects(
-        filtered_associations,
-        root_id: root_object_id,
-        filters: { type: class_for_type('object').name }
-      )
+      shortcircuit_ancestors = options[:filters].nil? && is_privilege?(user_or_attribute, operation, root_object)
+      candidates = if shortcircuit_ancestors
+                     ancestors = Assignment.ancestors_of(root_object)
+                     ancestors.or(PolicyElement.where(id: root_object_id))
+                   else
+                     PolicyElementAssociation.all_accessible_objects(
+                       filtered_associations,
+                       root_id: root_object_id,
+                       filters: { type: class_for_type('object').name }
+                     )
+                   end
 
       inclusion = options[:includes]
       if inclusion

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -777,20 +777,21 @@ module PolicyMachineStorageAdapter
     def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
       # If the root_object is a generic PM::Object, convert it the appropriate storage adapter Object
       root_object = root_object.try(:stored_pe) || root_object
+      root_object_id = root_object.id
+      operation = operation.try(:unique_identifier) || operation.to_s
 
-      # The final set of accessible objects must be ancestors of the root_object; avoid
-      # duplicate ancestor calls when possible
-      ancestor_objects = options[:ancestor_objects]
-      ancestor_objects ||= root_object.ancestors(type: class_for_type('object').name) + [root_object]
+      associations = associations_for_user_or_attribute(user_or_attribute, options)
+      filtered_associations = associations_filtered_by_operation(associations, operation)
 
-      # Short-circuit and return all ancestors (minus prohibitions) if the user_or_attribute
-      # is authorized on the root node
-      if options[:filters].nil? && is_privilege?(user_or_attribute, operation, root_object)
-        return all_ancestor_objects(user_or_attribute, operation, root_object, ancestor_objects, options)
+      candidates = PolicyElementAssociation.all_accessible_objects(
+        filtered_associations,
+        root_id: root_object_id
+      )
+
+      inclusion = options[:includes]
+      if inclusion
+        candidates = build_inclusion_scope(candidates, options[:key], inclusion)
       end
-
-      all_accessible_objects = objects_for_user_or_attribute_and_operation(user_or_attribute, operation, options)
-      candidates = all_accessible_objects & ancestor_objects
 
       if options[:ignore_prohibitions] || !(prohibition = prohibition_for(operation))
         candidates
@@ -798,23 +799,16 @@ module PolicyMachineStorageAdapter
         # Do not use the filter when checking prohibitions
         preloaded_options = options.except(:filters).merge(ignore_prohibitions: true)
         # If ancestor objects are filtered, preloaded ancestor objects cannot be used when checking prohibitions
-        preloaded_options.merge!(ancestor_objects: ancestor_objects) unless options[:filters]
-
         candidates - accessible_ancestor_objects(user_or_attribute, prohibition, root_object, preloaded_options)
       end
     end
+
 
     # Filters a list of associations to those related to a given operation
     def associations_filtered_by_operation(associations, operation)
       operation_id = operation.try(:unique_identifier) || operation.to_s
 
-      if associations.present?
-        operation_set_ids = associations.pluck(:operation_set_id)
-        filtered_operation_set_ids = Assignment.filter_operation_set_list_by_assigned_operation(operation_set_ids, operation_id)
-        associations.where(operation_set_id: filtered_operation_set_ids)
-      else
-        []
-      end
+      PolicyElementAssociation.with_accessible_operation(associations, operation_id)
     end
 
     private

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -803,7 +803,6 @@ module PolicyMachineStorageAdapter
       end
     end
 
-
     # Filters a list of associations to those related to a given operation
     def associations_filtered_by_operation(associations, operation)
       operation_id = operation.try(:unique_identifier) || operation.to_s

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -807,7 +807,11 @@ module PolicyMachineStorageAdapter
     def associations_filtered_by_operation(associations, operation)
       operation_id = operation.try(:unique_identifier) || operation.to_s
 
-      PolicyElementAssociation.with_accessible_operation(associations, operation_id)
+      if associations.present?
+        PolicyElementAssociation.with_accessible_operation(associations, operation_id)
+      else
+        []
+      end
     end
 
     private

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -785,7 +785,8 @@ module PolicyMachineStorageAdapter
 
       candidates = PolicyElementAssociation.all_accessible_objects(
         filtered_associations,
-        root_id: root_object_id
+        root_id: root_object_id,
+        filters: { type: class_for_type('object').name }
       )
 
       inclusion = options[:includes]

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -3,7 +3,7 @@ require 'active_record/hierarchical_query' # via gem activerecord-hierarchical_q
 module PolicyMachineStorageAdapter
   class ActiveRecord
     class PolicyElementAssociation
-      def self.all_accessible_objects(associations, root_id: nil, filters: {})
+      def self.all_accessible_objects(associations, root_id:, filters: {})
         pea_ids = associations.pluck(:id)
         return [] if pea_ids.empty?
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -23,7 +23,7 @@ module PolicyMachineStorageAdapter
                 ,a.parent_id
               FROM assignments a
               JOIN ancestors anc
-      ON anc.parent_id = a.child_id
+                ON anc.parent_id = a.child_id
             )
             ),
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -11,10 +11,10 @@ module PolicyMachineStorageAdapter
           id IN (
             WITH RECURSIVE ancestor_scope AS (
             SELECT
-                child_id,
-                child_id AS parent_id
-            FROM assignments
-            WHERE child_id = ?
+                id AS child_id,
+                id AS parent_id
+            FROM policy_elements
+            WHERE id = ?
 
             UNION ALL
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -9,8 +9,8 @@ module PolicyMachineStorageAdapter
             WITH RECURSIVE ancestors AS (
             (
               SELECT
-                objects.id AS parent_id
-                ,objects.id AS child_id
+                objects.id AS parent_id,
+                objects.id AS child_id
               FROM policy_element_associations peas
               JOIN policy_elements objects
                 ON objects.id = peas.object_attribute_id
@@ -19,8 +19,8 @@ module PolicyMachineStorageAdapter
             UNION ALL
             (
               SELECT
+                a.parent_id,
                 a.parent_id
-                ,a.parent_id
               FROM assignments a
               JOIN ancestors anc
                 ON anc.parent_id = a.child_id
@@ -30,16 +30,16 @@ module PolicyMachineStorageAdapter
             ancestor_scope AS (
             (
               SELECT
-                id AS parent_id
-                ,id AS child_id
+                id AS parent_id,
+                id AS child_id
               FROM policy_elements
               WHERE id = ?
             )
             UNION ALL
             (
               SELECT
-                a.parent_id
-                ,a.child_id
+                a.parent_id,
+                a.child_id
               FROM assignments a
               JOIN ancestor_scope anc
                 ON anc.parent_id = a.child_id

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -90,31 +90,32 @@ module PolicyMachineStorageAdapter
       def self.with_accessible_operation(associations, operation)
         query = <<-SQL
           operation_set_id IN (
-           WITH RECURSIVE accessible_operations AS (
+            WITH RECURSIVE accessible_operations AS (
               (
-               SELECT
+                SELECT
                   child_id,
                   parent_id,
                   parent_id AS operation_set_id
                 FROM assignments
                 WHERE parent_id IN (#{associations.select(:operation_set_id).to_sql})
               )
-             UNION ALL
+              UNION ALL
               (
                 SELECT
                   assignments.child_id,
                   assignments.parent_id,
-                 accessible_operations.operation_set_id AS operation_set_id
+                  accessible_operations.operation_set_id AS operation_set_id
                 FROM assignments
                 INNER JOIN accessible_operations
-                ON accessible_operations.child_id = assignments.parent_id
-             )
+                  ON accessible_operations.child_id = assignments.parent_id
+              )
             )
-          SELECT accessible_operations.operation_set_id
-          FROM accessible_operations
-         JOIN policy_elements ops
-            ON ops.id = accessible_operations.child_id
-          WHERE ops.unique_identifier = ?
+
+            SELECT accessible_operations.operation_set_id
+            FROM accessible_operations
+            JOIN policy_elements ops
+              ON ops.id = accessible_operations.child_id
+            WHERE ops.unique_identifier = ?
           )
         SQL
 


### PR DESCRIPTION
Hi, this PR adds optimizations to the ActiveRecord Adapter's `accessible_ancestor_objects` method. It moves a lot of the logic from Ruby to raw SQL. In benchmarks with trivial amounts of data, this new method is approximately 3.5x as fast as the old method: 
```ruby
old = lambda { ado_pm.accessible_ancestor_objects(u1, bluff, grandparent_fish, key: :unique_identifier) }
new = lambda { ado_pm.policy_machine_storage_adapter.new_accessible_ancestor_objects(u1, bluff, grandparent_fish, key: :unique_identifier) }
Benchmark.ips do |x|
  x.report("old") { old.call }
  x.report("new") { new.call }
  x.compare!
end
<<-RESULTS
Warming up --------------------------------------
                 old     7.000  i/100ms
                 new    26.000  i/100ms
Calculating -------------------------------------
                 old     74.303  (± 2.7%) i/s -    378.000  in   5.092408s
                 new    264.500  (± 3.0%) i/s -      1.326k in   5.017673s

Comparison:
                 new:      264.5 i/s
                 old:       74.3 i/s - 3.56x  slower
RESULTS
```

@mdsol/team04 - please review 