### PR TITLE
[MCC-521095] Allow preloading of policy element associations in .accessible_ancestor_objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0
+* Update .accessible_ancestor_objects to accept an optional associations_with_operation argument.
+* Update .accessible_ancestor_objects options argument to require a keyword.
+
 ## 2.1.2
 * Optimized ActiveRecord adapter for PolicyMachine `#accessible_ancestor_objects`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
-## 2.2.0
-* Update .accessible_ancestor_objects to accept an optional associations_with_operation argument.
-* Update .accessible_ancestor_objects options argument to require a keyword.
+## 2.1.3
+* Update .accessible_ancestor_objects to accept :associations_with_operation in its options argument.
 
 ## 2.1.2
 * Optimized ActiveRecord adapter for PolicyMachine `#accessible_ancestor_objects`.

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -284,14 +284,13 @@ class PolicyMachine
     end
   end
 
-  def accessible_ancestor_objects(user_or_attribute, operation, root_object, associations_with_operation = nil, options: {})
+  def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
     if policy_machine_storage_adapter.respond_to?(:accessible_ancestor_objects)
       policy_machine_storage_adapter.accessible_ancestor_objects(
         user_or_attribute,
         operation,
         root_object,
-        associations_with_operation,
-        options: options
+        options
       )
     else
       raise NoMethodError, "accessible_ancestor_objects is not implemented for storage adapter " \

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -284,9 +284,15 @@ class PolicyMachine
     end
   end
 
-  def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
+  def accessible_ancestor_objects(user_or_attribute, operation, root_object, associations_with_operation = nil, options: {})
     if policy_machine_storage_adapter.respond_to?(:accessible_ancestor_objects)
-      policy_machine_storage_adapter.accessible_ancestor_objects(user_or_attribute, operation, root_object, options)
+      policy_machine_storage_adapter.accessible_ancestor_objects(
+        user_or_attribute,
+        operation,
+        root_object,
+        associations_with_operation,
+        options: options
+      )
     else
       raise NoMethodError, "accessible_ancestor_objects is not implemented for storage adapter " \
                            "#{policy_machine_storage_adapter.class}."

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "2.2.0"
+  VERSION = "2.1.3"
 end

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "2.1.3"
+  VERSION = "2.2.0"
 end

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -775,14 +775,14 @@ module PolicyMachineStorageAdapter
     # Version of accessible_objects which only returns objects that are ancestors of a specified
     # root object or the object itself. A set of policy element associations with the specified
     # operation may be optionally provided.
-    def accessible_ancestor_objects(user_or_attribute, operation, root_object, associations_with_operation = nil, options: {})
+    def accessible_ancestor_objects(user_or_attribute, operation, root_object, options = {})
       # If the root_object is a generic PM::Object, convert it the appropriate storage adapter Object
       root_object = root_object.try(:stored_pe) || root_object
       root_object_id = root_object.id
       operation = operation.try(:unique_identifier) || operation.to_s
 
-      unless associations_with_operation
-        associations = associations_for_user_or_attribute(user_or_attribute, options)
+      unless associations_with_operation = options[:associations_with_operation]
+        associations = associations_for_user_or_attribute(user_or_attribute, options.except(:associations_with_operation))
         associations_with_operation = associations_filtered_by_operation(associations, operation)
       end
 
@@ -801,9 +801,9 @@ module PolicyMachineStorageAdapter
         candidates
       else
         # Do not use the filter when checking prohibitions
-        preloaded_options = options.except(:filters).merge(ignore_prohibitions: true)
+        preloaded_options = options.except(:filters, :associations_with_operation).merge(ignore_prohibitions: true)
         # If ancestor objects are filtered, preloaded ancestor objects cannot be used when checking prohibitions
-        candidates - accessible_ancestor_objects(user_or_attribute, prohibition, root_object, options: preloaded_options)
+        candidates - accessible_ancestor_objects(user_or_attribute, prohibition, root_object, preloaded_options)
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -772,8 +772,9 @@ module PolicyMachineStorageAdapter
       end
     end
 
-    # Version of accessible_objects which only returns objects that are
-    # ancestors of a specified root object or the object itself
+    # Version of accessible_objects which only returns objects that are ancestors of a specified
+    # root object or the object itself. A set of policy element associations with the specified
+    # operation may be optionally provided.
     def accessible_ancestor_objects(user_or_attribute, operation, root_object, associations_with_operation = nil, options: {})
       # If the root_object is a generic PM::Object, convert it the appropriate storage adapter Object
       root_object = root_object.try(:stored_pe) || root_object

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -1046,7 +1046,7 @@ module PolicyMachineStorageAdapter
           user_or_attribute,
           prohibition,
           root_object,
-          options: options.merge(ignore_prohibitions: true, ancestor_objects: ancestor_objects)
+          options.merge(ignore_prohibitions: true, ancestor_objects: ancestor_objects)
         )
         ancestor_objects - prohibited_ancestor_objects
       else


### PR DESCRIPTION
This PR updates `.accessible_ancestor_objects` to support an optional argument `associations_with_operation`. This bypasses the loading of PolicyElementAssociations for the user with the specified operation, if the relation has already been loaded.

Also updates the `options` argument to a keyword argument to reflect the optional `associations_with_operation`.
