### PR TITLE
[MCC-634582] Check prohibitions before checking if a priv exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.1
+* Optimize privilege exists lookup by checking prohibitions before performing privilege derivation.
+
 ## 3.0.0
 * Upgrade the Policy Machine to support Rails 6.0.
 * Drop support for Ruby versions 2.2.3, 2.3.0, 2.4.1 due to incompatibility with Rails 6.0.

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -90,16 +90,18 @@ class PolicyMachine
   # TODO: add option to ignore policy classes to allow consumer to speed up this method.
   # TODO: Parallelize the two component checks
   def is_privilege?(user_or_attribute, operation, object_or_attribute, options = {})
+    options_copy = options.deep_dup
     (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
-      is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options)
+      is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options_copy)
   end
 
   ##
   # Can we derive a privilege given a set of filters?
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     # Check that the privilege can be derived given the set of filters, but do not filter the check for prohibitions
+    options_copy = options.deep_dup
     (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
-      is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options)
+      is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options_copy)
   end
 
   ##

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -90,9 +90,7 @@ class PolicyMachine
   # TODO: add option to ignore policy classes to allow consumer to speed up this method.
   # TODO: Parallelize the two component checks
   def is_privilege?(user_or_attribute, operation, object_or_attribute, options = {})
-    # Deep copy options hash to fix issue where it is being mutated after first 'is_privilege_ignoring_prohibitions?' call.
-    options_copy = options.deep_dup
-    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options_copy)) &&
+    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
       is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options)
   end
 
@@ -100,8 +98,7 @@ class PolicyMachine
   # Can we derive a privilege given a set of filters?
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     # Check that the privilege can be derived given the set of filters, but do not filter the check for prohibitions
-    options_copy = options.deep_dup
-    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options_copy)) &&
+    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
       is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options)
   end
 
@@ -140,7 +137,7 @@ class PolicyMachine
       raise(ArgumentError, "options[:associations] cannot be empty") if associations.empty?
       raise(ArgumentError, "expected each element of options[:associations] to be a PM::Association") unless associations.all?{|a| a.is_a?(PM::Association)}
 
-      associations.keep_if do |association|
+      associations = associations.select do |association|
         association.operation_set.connected?(operation)
       end
       return false if associations.empty?

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -90,10 +90,10 @@ class PolicyMachine
   # TODO: add option to ignore policy classes to allow consumer to speed up this method.
   # TODO: Parallelize the two component checks
   def is_privilege?(user_or_attribute, operation, object_or_attribute, options = {})
-    # Fixes situation where options hash's values are deleting after first is_privilege_ignoring_prohibitions? call.
+    # Deep copy options hash to fix issue where it is being mutated after first 'is_privilege_ignoring_prohibitions?' call.
     options_copy = options.deep_dup
-    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
-      is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options_copy)
+    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options_copy)) &&
+      is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options)
   end
 
   ##
@@ -101,8 +101,8 @@ class PolicyMachine
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     # Check that the privilege can be derived given the set of filters, but do not filter the check for prohibitions
     options_copy = options.deep_dup
-    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
-      is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options_copy)
+    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options_copy)) &&
+      is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options)
   end
 
   ##

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -90,6 +90,7 @@ class PolicyMachine
   # TODO: add option to ignore policy classes to allow consumer to speed up this method.
   # TODO: Parallelize the two component checks
   def is_privilege?(user_or_attribute, operation, object_or_attribute, options = {})
+    # Fixes situation where options hash's values are deleting after first is_privilege_ignoring_prohibitions? call.
     options_copy = options.deep_dup
     (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
       is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options_copy)

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -90,16 +90,16 @@ class PolicyMachine
   # TODO: add option to ignore policy classes to allow consumer to speed up this method.
   # TODO: Parallelize the two component checks
   def is_privilege?(user_or_attribute, operation, object_or_attribute, options = {})
-    is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options) &&
-      (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
+    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
+      is_privilege_ignoring_prohibitions?(user_or_attribute, operation, object_or_attribute, options)
   end
 
   ##
   # Can we derive a privilege given a set of filters?
   def is_privilege_with_filters?(user_or_attribute, operation, object_or_attribute, filters: {}, options: {})
     # Check that the privilege can be derived given the set of filters, but do not filter the check for prohibitions
-    is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options) &&
-       (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options))
+    (options[:ignore_prohibitions] || !is_privilege_ignoring_prohibitions?(user_or_attribute, PM::Prohibition.on(operation), object_or_attribute, options)) &&
+      is_privilege_ignoring_prohibitions_with_filters?(user_or_attribute, operation, object_or_attribute, filters: filters, options: options)
   end
 
   ##

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -137,10 +137,9 @@ class PolicyMachine
       raise(ArgumentError, "options[:associations] cannot be empty") if associations.empty?
       raise(ArgumentError, "expected each element of options[:associations] to be a PM::Association") unless associations.all?{|a| a.is_a?(PM::Association)}
 
-      associations = associations.select do |association|
+      return false if associations.none? do |association|
         association.operation_set.connected?(operation)
       end
-      return false if associations.empty?
     else
       associations = operation.associations
     end


### PR DESCRIPTION
Background
- When performing a privilege exists lookup, Dalton (via the policy machine) checks if an operator is prohibited on the requested operable after it has checked if the user has access the to the given operable via the requested permission.

Changes
- Check prohibitions first before performing privilege derivation.

Tests
- Sample size of 1000
- Setting `ignore_prohibitions` to `true` results in an average response time of 1.42751863352 seconds
- Setting `ignore_prohibitions`to `false` results in an average response time of 2.19180535417 seconds 

Setting `ignore_prohibitions` to `true` is ~53.54% faster. 