### PR TITLE
[MCC-606611] all_operations_for_user_or_attr_and_objs_or_attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.0
 * Added `PolicyMachine#all_operations_for_user_or_attr_and_objs_or_attrs` for finding a map of all operations
-  between give objects and a given user.
+  between given objects and a given user.
 
 ## 3.2.0
 * Added `PolicyMachine#accessible_objects_for_operations` for finding a map of accessible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 3.3.0
 * Added `PolicyMachine#all_operations_for_user_or_attr_and_objs_or_attrs` for finding a map of all operations
   between given objects and a given user.
+* Added `PM::Operation.prohibition?` method which takes a unique identifier and returns a boolean indicating
+  whether it represents a prohibition.
 
 ## 3.2.0
 * Added `PolicyMachine#accessible_objects_for_operations` for finding a map of accessible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.0
+* Added `PolicyMachine#all_operations_for_user_or_attr_and_objs_or_attrs` for finding a map of all operations
+  between give objects and a given user.
+
 ## 3.2.0
 * Added `PolicyMachine#accessible_objects_for_operations` for finding a map of accessible
   objects per operation for multiple operations. Only implemented in `ActiveRecord` and

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -292,12 +292,12 @@ class PolicyMachine
     end
   end
 
-  def accessible_operations_for_user_or_attribute_and_object(user_or_attribute, object_attribute_ids, options = {})
-    unless policy_machine_storage_adapter.respond_to?(:accessible_operations_for_user_or_attribute_and_object)
+  def all_operations_for_user_or_attr_and_objs_or_attrs(user_or_attribute, object_attribute_ids, options = {})
+    unless policy_machine_storage_adapter.respond_to?(:all_operations_for_user_or_attr_and_objs_or_attrs)
       adapter = policy_machine_storage_adapter.class
-      raise NoMethodError, "accessible_operations_for_user_or_attribute_and_object is not implemented for storage adapter #{adapter}"
+      raise NoMethodError, "all_operations_for_user_or_attr_and_objs_or_attrs is not implemented for storage adapter #{adapter}"
     end
-    policy_machine_storage_adapter.accessible_operations_for_user_or_attribute_and_object(user_or_attribute, object_attribute_ids, options)
+    policy_machine_storage_adapter.all_operations_for_user_or_attr_and_objs_or_attrs(user_or_attribute, object_attribute_ids, options)
   end
 
   def accessible_objects_for_operations(user_or_attribute, operations, options = {})

--- a/lib/policy_machine.rb
+++ b/lib/policy_machine.rb
@@ -292,6 +292,14 @@ class PolicyMachine
     end
   end
 
+  def accessible_operations_for_user_or_attribute_and_object(user_or_attribute, object_attribute_ids, options = {})
+    unless policy_machine_storage_adapter.respond_to?(:accessible_operations_for_user_or_attribute_and_object)
+      adapter = policy_machine_storage_adapter.class
+      raise NoMethodError, "accessible_operations_for_user_or_attribute_and_object is not implemented for storage adapter #{adapter}"
+    end
+    policy_machine_storage_adapter.accessible_operations_for_user_or_attribute_and_object(user_or_attribute, object_attribute_ids, options)
+  end
+
   def accessible_objects_for_operations(user_or_attribute, operations, options = {})
     unless policy_machine_storage_adapter.respond_to?(:accessible_objects_for_operations)
       adapter = policy_machine_storage_adapter.class

--- a/lib/policy_machine/policy_element.rb
+++ b/lib/policy_machine/policy_element.rb
@@ -215,6 +215,10 @@ module PM
       end
     end
 
+    def self.prohibition?(unique_identifier)
+      unique_identifier.start_with?('~')
+    end
+
     def to_s
       unique_identifier
     end
@@ -228,7 +232,7 @@ module PM
     end
 
     def prohibition?
-      unique_identifier =~ /^~/
+      self.class.prohibition?(unique_identifier)
     end
 
     # Return all associations in which this Operation is included

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "3.2.0"
+  VERSION = "3.3.0"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -822,7 +822,7 @@ module PolicyMachineStorageAdapter
       unless options[:ignore_prohibitions]
         prohibited_operation_names = Set.new(operation_names.select { |op| op.start_with?('~') })
 
-        operation_names.reject do |op|
+        operation_names.reject! do |op|
           op.start_with?('~') || prohibited_operation_names.include?(prohibition_identifier(op))
         end
       end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -977,9 +977,6 @@ module PolicyMachineStorageAdapter
       PolicyElementAssociation.where(user_attribute_id: user_attribute_ids)
     end
 
-    # SQL will run
-    # select * from peas  where user_attribute_id IN (fidfiosdhgidos) and object_attribute
-
     # Builds an array of PolicyElement objects within the scope of a given
     # array of associations
     def build_accessible_object_scope(associations, options = {})

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -826,7 +826,7 @@ module PolicyMachineStorageAdapter
       end
 
       opset_id_operation_rows = PolicyElement.operations_for_operation_sets(
-        obj_attr_ids_to_opset_ids.values.flatten.uniq,
+        obj_attr_ids_to_opset_ids.values.flatten.uniq
       )
 
       # generate a hash of opset ids to lists of operations the opsets contain

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -817,8 +817,13 @@ module PolicyMachineStorageAdapter
         object_attribute_id: object_attribute_ids
       ).pluck(:operation_set_id, :object_attribute_id)
 
-      # generate a hash of object attribute ids to lists of operation sets from their
+      # generate a hash of object attribute ids to lists of operation set ids from their
       # associations with the given user / user attribute
+      # ex:
+      # {
+      #   obj_attr1_id => [opset1_id, opset2_id, opset3_id],
+      #   obj_attr2_id => [opset1_id],
+      # }
       obj_attr_ids_to_opset_ids = opset_ids_and_obj_attr_ids.each_with_object(
         Hash.new { |h, k| h[k] = [] }
       ) do |(opset_id, objattr_id), acc|
@@ -830,6 +835,12 @@ module PolicyMachineStorageAdapter
       )
 
       # generate a hash of opset ids to lists of operations the opsets contain
+      # ex:
+      # {
+      #   opset1_id => ['read', 'write', 'foo', '~bar'],
+      #   opset2_id => ['read', 'edit', '~foo'],
+      #   opset3_id => ['create_zagnuts'],
+      # }
       opset_ids_to_operations = opset_id_operation_rows.each_with_object(
         Hash.new { |h, k| h[k] = [] }
       ) do |row, acc|
@@ -837,6 +848,11 @@ module PolicyMachineStorageAdapter
       end
 
       # stitch the two hashes together to get object attribute ids to lists of operations
+      # ex:
+      # {
+      #   obj_attr1_id => ['read', 'write', 'foo', '~bar', 'edit', '~foo', 'create_zagnuts'],
+      #   obj_attr2_id => ['read', 'write', 'foo', '~bar'],
+      # }
       obj_attr_ids_to_opset_ids.each_with_object({}) do |(obj_attr_id, opset_ids), memo|
         memo[obj_attr_id] = opset_ids.flat_map { |opset_id| opset_ids_to_operations[opset_id] || [] }.uniq
       end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -953,12 +953,7 @@ module PolicyMachineStorageAdapter
         operations
       )
 
-      # generate a hash like:
-      # {
-      #   'operation1' => [123],
-      #   'operation2' => [123, 789],
-      #   'operation3' => [789],
-      # }
+      # generate a hash of operations to lists of the ids of operation sets that contain them
       operations_to_filtered_opset_ids = opset_ids_operation_rows.to_a.each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, acc|
         acc[row['unique_identifier']] << row['operation_set_id']
       end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -322,67 +322,73 @@ describe 'ActiveRecord' do
           priv_pm.add_association(color_4, sketcher, object_7)
         end
 
-        it 'returns operations for the given object_attribute_id with single association' do
-          result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
-            user_1,
-            [object_7.id]
-          )
+        context 'single association' do
+          it 'returns operations for the given object_attribute_id' do
+            result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
+              user_1,
+              [object_7.id]
+            )
 
-          expect(result[object_7.id]).to contain_exactly(sketch.to_s)
+            expect(result[object_7.id]).to contain_exactly(sketch.to_s)
+          end
         end
 
-        it 'returns operations for the given object_attribute_id with multiple associations' do
-          priv_pm.add_association(color_3, painter, object_7)
-
-          result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
-            user_1,
-            [object_7.id]
-          )
-
-          expect(result[object_7.id]).to contain_exactly(paint.to_s, sketch.to_s)
-        end
-
-        it 'returns operations for multiple object_attribute_ids' do
-          result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
-            user_1,
-            [oa_1.id, object_7.id]
-          )
-
-          expect(result[oa_1.id]).to contain_exactly(create.to_s, paint.to_s)
-          expect(result[object_7.id]).to contain_exactly(sketch.to_s)
-        end
-
-        context 'prohibitions' do
-          let(:cant_paint) { priv_pm.create_operation_set('cant_paint') }
-
+        context 'multiple associations' do
           before do
-            priv_pm.add_assignment(cant_paint, paint.prohibition)
-            priv_pm.add_association(color_3, cant_paint, object_7)
             priv_pm.add_association(color_3, painter, object_7)
           end
 
-          it 'returns prohibited operations' do
-            result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
-              user_1,
-              [object_7.id],
-            )
-
-            expect(result[object_7.id]).to contain_exactly(sketch.to_s, paint.to_s, paint.prohibition.to_s)
-          end
-        end
-
-        context 'filters' do
-          let(:filters) { { user_attributes: { color: color_3.color } } }
-
-          it 'they work' do
+          it 'returns operations for the given object_attribute_id' do
             priv_pm.add_association(color_3, painter, object_7)
+
             result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
               user_1,
-              [object_7.id],
-              filters: filters
+              [object_7.id]
             )
 
-          expect(result[object_7.id]).to contain_exactly(paint.to_s)
+            expect(result[object_7.id]).to contain_exactly(paint.to_s, sketch.to_s)
+          end
+
+          it 'returns operations for multiple object_attribute_ids' do
+            result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
+              user_1,
+              [oa_1.id, object_7.id]
+            )
+
+            expect(result[oa_1.id]).to contain_exactly(create.to_s, paint.to_s)
+            expect(result[object_7.id]).to contain_exactly(sketch.to_s, paint.to_s)
+          end
+
+          context 'prohibitions' do
+            let(:cant_paint) { priv_pm.create_operation_set('cant_paint') }
+
+            before do
+              priv_pm.add_assignment(cant_paint, paint.prohibition)
+              priv_pm.add_association(color_3, cant_paint, object_7)
+            end
+
+            it 'returns prohibited operations' do
+              result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
+                user_1,
+                [object_7.id],
+              )
+
+              expect(result[object_7.id]).to contain_exactly(sketch.to_s, paint.to_s, paint.prohibition.to_s)
+            end
+          end
+
+          context 'filters' do
+            let(:filters) { { user_attributes: { color: color_3.color } } }
+
+            it 'they work' do
+              result = priv_pm.all_operations_for_user_or_attr_and_objs_or_attrs(
+                user_1,
+                [object_7.id],
+                filters: filters
+              )
+
+            expect(result[object_7.id]).to contain_exactly(paint.to_s)
+            end
           end
         end
       end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -387,7 +387,7 @@ describe 'ActiveRecord' do
                 filters: filters
               )
 
-            expect(result[object_7.id]).to contain_exactly(paint.to_s)
+              expect(result[object_7.id]).to contain_exactly(paint.to_s)
             end
           end
         end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -328,8 +328,7 @@ describe 'ActiveRecord' do
               user_1,
               [object_7.id]
             )
-
-            expect(result[object_7.id]).to contain_exactly(sketch.to_s)
+            expect(result).to eq({ object_7.id => [sketch.to_s] })
           end
         end
 
@@ -345,7 +344,7 @@ describe 'ActiveRecord' do
               user_1,
               [object_7.id]
             )
-
+            expect(result.keys).to contain_exactly(object_7.id)
             expect(result[object_7.id]).to contain_exactly(paint.to_s, sketch.to_s)
           end
 
@@ -354,7 +353,7 @@ describe 'ActiveRecord' do
               user_1,
               [oa_1.id, object_7.id]
             )
-
+            expect(result.keys).to contain_exactly(oa_1.id, object_7.id)
             expect(result[oa_1.id]).to contain_exactly(create.to_s, paint.to_s)
             expect(result[object_7.id]).to contain_exactly(sketch.to_s, paint.to_s)
           end
@@ -372,7 +371,7 @@ describe 'ActiveRecord' do
                 user_1,
                 [object_7.id],
               )
-
+              expect(result.keys).to contain_exactly(object_7.id)
               expect(result[object_7.id]).to contain_exactly(sketch.to_s, paint.to_s, paint.prohibition.to_s)
             end
           end
@@ -386,7 +385,7 @@ describe 'ActiveRecord' do
                 [object_7.id],
                 filters: filters
               )
-
+              expect(result.keys).to contain_exactly(object_7.id)
               expect(result[object_7.id]).to contain_exactly(paint.to_s)
             end
           end


### PR DESCRIPTION
Adds the function `PolicyMachine#all_operations_for_user_or_attr_and_objs_or_attrs`  to  return a map of all operations between a given list of objects or object attribute ids and  a  single given  user  or user attribute.