### PR TITLE
[MCC-752251] Fix Policy Machine constant resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.1
+* Fix intermittent incorrect constant resolution.
+
 ## 3.3.0
 * Added `PolicyMachine#all_operations_for_user_or_attr_and_objs_or_attrs` for finding a map of all operations
   between given objects and a given user.

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "3.3.0"
+  VERSION = "3.3.1"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -26,7 +26,7 @@ module PolicyMachineStorageAdapter
     def self.const_missing(name)
       if %w[Assignment LogicalLink Adapter].include?(name.to_s)
         load_db_adapter!
-        const_get(name)
+        "::PolicyMachineStorageAdapter::ActiveRecord::#{name.to_s}".constantize
       else
         super
       end


### PR DESCRIPTION
Background-
An error occurs occassionally in all environments where PM receives a constant incorrectly fails and to resolve the same.
Following error is thrown:
Returning an error with status {:status=>:internal_server_error, :message=>“Error message stored in logs”}, NameError: uninitialized constant PolicyMachineStorageAdapter::ActiveRecord::PolicyElement::Assignment

**Constant Received**
PolicyMachineStorageAdapter::ActiveRecord::PolicyElement::Assignment
**Actual class**
PolicyMachineStorageAdapter::ActiveRecord::Assignment

This PR aims to provide the absolute scope for constant resolution.