### PR TITLE
[MCC-773364] Fix filter+prohibition logic in `accessible_objects_for_operations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 3.3.2
+* Fixed incorrect handling of filters with prohibitions in ActiveRecord `accessible_objects_for_operations`.
+
 ## 3.3.1
-* Fix intermittent incorrect constant resolution.
+* Fixed intermittent incorrect constant resolution.
 
 ## 3.3.0
 * Added `PolicyMachine#all_operations_for_user_or_attr_and_objs_or_attrs` for finding a map of all operations

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "3.3.1"
+  VERSION = "3.3.2"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -983,7 +983,7 @@ module PolicyMachineStorageAdapter
       #   'write' => [opset1_id],
       #   'delete' => [opset2_id],
       # }
-      operations_to_opset_ids = opset_id_operation_rows.to_a.each_with_object(
+      operations_to_opset_ids = opset_id_operation_rows.each_with_object(
         Hash.new { |h, k| h[k] = [] }
       ) do |row, acc|
         acc[row['unique_identifier']] << row['operation_set_id']

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -817,8 +817,8 @@ module PolicyMachineStorageAdapter
         object_attribute_id: object_attribute_ids
       ).pluck(:operation_set_id, :object_attribute_id)
 
-      # generate a hash of object attribute ids to lists of operation set ids from their
-      # associations with the given user / user attribute
+      # generate a hash of object attribute ids to lists of operation set ids
+      # from the given user_or_attribute's associations
       # ex:
       # {
       #   obj_attr1_id => [opset1_id, opset2_id, opset3_id],
@@ -853,8 +853,8 @@ module PolicyMachineStorageAdapter
       #   obj_attr1_id => ['read', 'write', 'foo', '~bar', 'edit', '~foo', 'create_zagnuts'],
       #   obj_attr2_id => ['read', 'write', 'foo', '~bar'],
       # }
-      obj_attr_ids_to_opset_ids.each_with_object({}) do |(obj_attr_id, opset_ids), memo|
-        memo[obj_attr_id] = opset_ids.flat_map { |opset_id| opset_ids_to_operations[opset_id] || [] }.uniq
+      obj_attr_ids_to_opset_ids.transform_values do |opset_ids|
+        opset_ids.map { |opset_id| opset_ids_to_operations[opset_id] || [] }.reduce(:|)
       end
     end
 
@@ -870,20 +870,23 @@ module PolicyMachineStorageAdapter
       # default objects for each operation to empty list
       accessible_map = operation_names.map { |o| [o, []] }.to_h
 
-      if options[:ignore_prohibitions]
-        accessible_map.merge!(
-          objects_for_user_or_attribute_and_operations(user_or_attribute, operation_names, options)
-        )
-        return accessible_map
-      end
+      accessible_map.merge!(objects_for_user_or_attribute_and_operations(
+        user_or_attribute,
+        operation_names,
+        options
+      ))
+
+      return accessible_map if options[:ignore_prohibitions]
 
       # using `prohibitions_for` rather than just mapping to `prohibition_identifier`
       # because we want to confirm that these prohibitions exist in the db
       prohibition_names = prohibitions_for(operation_names).map { |p| operation_identifier(p) }
-      op_and_prohib_names = operation_names + prohibition_names
-      accessible_map.merge!(
-        objects_for_user_or_attribute_and_operations(user_or_attribute, op_and_prohib_names, options)
-      )
+
+      accessible_map.merge!(objects_for_user_or_attribute_and_operations(
+        user_or_attribute,
+        prohibition_names,
+        options.except(:filters)
+      ))
 
       operation_names.each do |operation_name|
         prohibition_name = prohibition_identifier(operation_name)
@@ -954,8 +957,13 @@ module PolicyMachineStorageAdapter
       return {} if operations.empty?
       associations = associations_for_user_or_attribute(user_or_attribute, options)
 
-      # the operation set IDs and the object attribute IDs they connect to
-      # from the user_or_attribute's associations
+      # generate a hash of operation set ids to lists of object attribute ids
+      # from the given user_or_attribute's associations
+      # ex:
+      # {
+      #   opset1_id => [obj_attr1_id, obj_attr2_id, obj_attr3_id],
+      #   opset2_id => [obj_attr1_id],
+      # }
       opset_ids_to_objattr_ids = associations.pluck(
         :operation_set_id,
         :object_attribute_id
@@ -963,19 +971,32 @@ module PolicyMachineStorageAdapter
         acc[opset_id] << objattr_id
       end
 
-      # operation names to list of operation set IDs (from UA's associations) that contain them
-      opset_ids_operation_rows = PolicyElement.operations_for_operation_sets(
-        opset_ids_to_objattr_ids.keys, # operation set IDs from UA's associations
+      opset_id_operation_rows = PolicyElement.operations_for_operation_sets(
+        opset_ids_to_objattr_ids.keys,
         operations
       )
 
-      # generate a hash of operations to lists of the ids of operation sets that contain them
-      operations_to_filtered_opset_ids = opset_ids_operation_rows.to_a.each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, acc|
+      # generate a hash of operation names to lists of the ids of operation sets that contain them
+      # ex:
+      # {
+      #   'read' => [opset1_id, opset2_id],
+      #   'write' => [opset1_id],
+      #   'delete' => [opset2_id],
+      # }
+      operations_to_opset_ids = opset_id_operation_rows.to_a.each_with_object(
+        Hash.new { |h, k| h[k] = [] }
+      ) do |row, acc|
         acc[row['unique_identifier']] << row['operation_set_id']
       end
 
-      # replace lists operation set IDs with lists of object attribute IDs
-      operations_to_objattr_ids = operations_to_filtered_opset_ids.transform_values do |opset_ids|
+      # stitch the two hashes together to get operation names to lists of object attribute ids
+      # ex:
+      # {
+      #   'read' => [obj_attr1_id, obj_attr2_id, obj_attr3_id],
+      #   'write' => [obj_attr1_id, obj_attr2_id, obj_attr3_id],
+      #   'delete' => [obj_attr1_id],
+      # }
+      operations_to_objattr_ids = operations_to_opset_ids.transform_values do |opset_ids|
         opset_ids.map { |opset_id| opset_ids_to_objattr_ids[opset_id] || [] }.reduce(:|)
       end
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -64,6 +64,14 @@ module PolicyMachineStorageAdapter
         #   (789, operation2)
         #   (789, operation3)
         #
+        # NOTE:
+        # actual output will be row hashes like:
+        # [
+        #   { 'operation_set_id' => 123, 'unique_identifier' => 'operation1' },
+        #   { 'operation_set_id' => 123, 'unique_identifier' => 'operation2' },
+        #   { 'operation_set_id' => 789, 'unique_identifier' => 'operation2' },
+        #   { 'operation_set_id' => 789, 'unique_identifier' => 'operation3' },
+        # ]
         connection.execute(sanitized_query)
       end
     end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -467,6 +467,7 @@ describe 'ActiveRecord' do
 
             context 'prohibitions' do
               let(:cant_create) { priv_pm.create_operation_set('cant_create') }
+              let(:filters) { { user_attributes: { color: color_1.color } } }
 
               before do
                 priv_pm.add_assignment(cant_create, create.prohibition)
@@ -487,6 +488,21 @@ describe 'ActiveRecord' do
                 expect(result.keys).to contain_exactly(create.to_s, paint.to_s)
                 expect(result[create.to_s]).to contain_exactly(object_7.stored_pe)
                 expect(result[paint.to_s]).to contain_exactly(object_6.stored_pe, object_7.stored_pe)
+              end
+
+              # prohibition applied via color_2 still blocks create on object_6,
+              # even though we are filtering via color_1
+              it 'ignores filters for prohibitions' do
+                result = priv_pm.accessible_objects_for_operations(
+                  user_1,
+                  [create, paint],
+                  filters: filters,
+                  direct_only: true
+                )
+                expect(result).to eq({
+                  create.to_s => [],
+                  paint.to_s => [object_6.stored_pe],
+                })
               end
             end
           end


### PR DESCRIPTION
@mdsol/team04 this is just for correctness.  In Dalton we only use this with `ignore_prohibitions=true` because reasons.