### PR TITLE
[MCC-826703] Add option for object fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.4
+* Added `fields` option to `PolicyMachineStorageAdapter::ActiveRecord` for `#accessible_objects` and
+  `#accessible_objects_for_operations` to fetch only requested fields as a hash.
+
 ## 3.3.3
 * Fixed a deprecation warning from Rails 6.1.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "3.3.3"
+  VERSION = "3.3.4"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -1068,7 +1068,10 @@ module PolicyMachineStorageAdapter
       objects = PolicyElement.where(id: ids)
 
       if fields
-        objects.pluck(*fields).map { |values| fields.zip(values).to_h }
+        objects.pluck(*fields).map do |values|
+          values = [values] if fields.one?
+          fields.zip(values).to_h
+        end
       else
         objects.to_a
       end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -309,6 +309,43 @@ describe 'ActiveRecord' do
             ).class).to eq(Array)
           end
         end
+
+        context 'fields' do
+          it 'plucks only requested fields' do
+            expect(
+              priv_pm.accessible_objects(
+                user_1,
+                create,
+                fields: [:unique_identifier, :policy_machine_uuid]
+              )
+            ).to match_array([
+              {
+                unique_identifier: object_1.unique_identifier,
+                policy_machine_uuid: priv_pm.uuid
+              },
+              {
+                unique_identifier: object_2.unique_identifier,
+                policy_machine_uuid: priv_pm.uuid
+              },
+              {
+                unique_identifier: object_3.unique_identifier,
+                policy_machine_uuid: priv_pm.uuid
+              },
+              {
+                unique_identifier: object_4.unique_identifier,
+                policy_machine_uuid: priv_pm.uuid
+              },
+              {
+                unique_identifier: object_5.unique_identifier,
+                policy_machine_uuid: priv_pm.uuid
+              },
+              {
+                unique_identifier: object_6.unique_identifier,
+                policy_machine_uuid: priv_pm.uuid
+              }
+            ])
+          end
+        end
       end
 
       describe 'all_operations_for_user_or_attr_and_objs_or_attrs' do
@@ -503,6 +540,46 @@ describe 'ActiveRecord' do
                   create.to_s => [],
                   paint.to_s => [object_6.stored_pe],
                 })
+              end
+            end
+
+            context 'fields' do
+              it 'plucks only requested fields' do
+                result = priv_pm.accessible_objects_for_operations(
+                  user_1,
+                  [create, paint],
+                  direct_only: true,
+                  fields: [:unique_identifier, :id]
+                )
+
+                expect(result.keys).to contain_exactly(create.to_s, paint.to_s)
+                expect(result[create.to_s]).to contain_exactly(
+                  { id: object_6.id, unique_identifier: object_6.unique_identifier },
+                  { id: object_7.id, unique_identifier: object_7.unique_identifier }
+                )
+                expect(result[paint.to_s]).to contain_exactly(
+                  { id: object_6.id, unique_identifier: object_6.unique_identifier },
+                  { id: object_7.id, unique_identifier: object_7.unique_identifier }
+                )
+              end
+
+              it 'does not include id implicitly' do
+                result = priv_pm.accessible_objects_for_operations(
+                  user_1,
+                  [create, paint],
+                  direct_only: true,
+                  fields: [:unique_identifier]
+                )
+
+                expect(result.keys).to contain_exactly(create.to_s, paint.to_s)
+                expect(result[create.to_s]).to contain_exactly(
+                  { unique_identifier: object_6.unique_identifier },
+                  { unique_identifier: object_7.unique_identifier }
+                )
+                expect(result[paint.to_s]).to contain_exactly(
+                  { unique_identifier: object_6.unique_identifier },
+                  { unique_identifier: object_7.unique_identifier }
+                )
               end
             end
           end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -358,6 +358,23 @@ describe 'ActiveRecord' do
               }
             ])
           end
+
+          it 'plucks a single field' do
+            expect(
+              priv_pm.accessible_objects(
+                user_1,
+                create,
+                fields: [:unique_identifier]
+              )
+            ).to match_array([
+              { unique_identifier: object_1.unique_identifier },
+              { unique_identifier: object_2.unique_identifier },
+              { unique_identifier: object_3.unique_identifier },
+              { unique_identifier: object_4.unique_identifier },
+              { unique_identifier: object_5.unique_identifier },
+              { unique_identifier: object_6.unique_identifier }
+            ])
+          end
         end
       end
 
@@ -573,6 +590,25 @@ describe 'ActiveRecord' do
                 expect(result[paint.to_s]).to contain_exactly(
                   { id: object_6.id, unique_identifier: object_6.unique_identifier },
                   { id: object_7.id, unique_identifier: object_7.unique_identifier }
+                )
+              end
+
+              it 'plucks a single field' do
+                result = priv_pm.accessible_objects_for_operations(
+                  user_1,
+                  [create, paint],
+                  direct_only: true,
+                  fields: [:unique_identifier]
+                )
+
+                expect(result.keys).to contain_exactly(create.to_s, paint.to_s)
+                expect(result[create.to_s]).to contain_exactly(
+                  { unique_identifier: object_6.unique_identifier },
+                  { unique_identifier: object_7.unique_identifier }
+                )
+                expect(result[paint.to_s]).to contain_exactly(
+                  { unique_identifier: object_6.unique_identifier },
+                  { unique_identifier: object_7.unique_identifier }
                 )
               end
 

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -310,6 +310,19 @@ describe 'ActiveRecord' do
           end
         end
 
+        context 'includes' do
+          it 'returns only objects that match' do
+            expect(
+              priv_pm.accessible_objects(
+                user_1,
+                create,
+                key: :unique_identifier,
+                includes: '4'
+              ).map(&:unique_identifier)
+            ).to eq(['object_4'])
+          end
+        end
+
         context 'fields' do
           it 'plucks only requested fields' do
             expect(


### PR DESCRIPTION
Changes:

`#accessible_objects`

* Added `fields` to `#build_accessible_object_scope`
* ~There are a few `SELECT "policy_elements".*` invoked which are not addressed. Instead, a simple `slice` after the fact.~
  * ~A more traditional `pluck` can be used with some additional work. I'm not certain at this time if there is a performance need for it.~
  * ~I didn't spot any specs for `options[:includes]` which I think should be added if we want to ensure pluck works for all situations. Maybe we should add specs here regardless?~
* Uses pluck where possible to minimize unnecessary instantiated objects.
* Added specs for `includes` option.

## SQL comparison: 

<details>
  <summary>Before</summary>

```SQL
D, [2021-10-12T14:50:17.727679 #14279] DEBUG -- :    (0.8ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE (          id IN (
            WITH RECURSIVE assignments_recursive AS (
              (
                SELECT child_id, parent_id
                FROM assignments
                WHERE parent_id in (1)
              )
              UNION ALL
              (
                SELECT assignments.child_id, assignments.parent_id
                FROM assignments
                INNER JOIN assignments_recursive
                ON assignments_recursive.child_id = assignments.parent_id
              )
            )

            SELECT assignments_recursive.child_id
            FROM assignments_recursive
          )
)
D, [2021-10-12T14:50:17.730365 #14279] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::PolicyElementAssociation Load (0.4ms)  SELECT "policy_element_associations".* FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN ($1, $2, $3, $4)  [["user_attribute_id", 2], ["user_attribute_id", 3], ["user_attribute_id", 4], ["user_attribute_id", 1]]
D, [2021-10-12T14:50:17.732689 #14279] DEBUG -- :    (1.2ms)  SELECT "policy_element_associations"."object_attribute_id" FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN ($1, $2, $3, $4) AND (          operation_set_id IN (
            WITH RECURSIVE accessible_operations AS (
              (
                SELECT
                  child_id,
                  parent_id,
                  parent_id AS operation_set_id
                FROM assignments
                WHERE parent_id IN (SELECT "policy_element_associations"."operation_set_id" FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN (2, 3, 4, 1))
              )
              UNION ALL
              (
                SELECT
                  assignments.child_id,
                  assignments.parent_id,
                  accessible_operations.operation_set_id AS operation_set_id
                FROM assignments
                INNER JOIN accessible_operations
                  ON accessible_operations.child_id = assignments.parent_id
              )
            )

            SELECT accessible_operations.operation_set_id
            FROM accessible_operations
            JOIN policy_elements ops
              ON ops.id = accessible_operations.child_id
            WHERE ops.unique_identifier = 'create'
          )
)  [["user_attribute_id", 2], ["user_attribute_id", 3], ["user_attribute_id", 4], ["user_attribute_id", 1]]
D, [2021-10-12T14:50:17.734928 #14279] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::PolicyElement Load (1.4ms)  SELECT "policy_elements".* FROM "policy_elements" WHERE "policy_elements"."id" IN ($1, $2)  [["id", 13], ["id", 8]]
D, [2021-10-12T14:50:17.737085 #14279] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::PolicyElement Load (0.6ms)  SELECT "policy_elements".* FROM "policy_elements" WHERE "policy_elements"."id" IN ($1, $2) AND "policy_elements"."type" = $3  [["id", 13], ["id", 8], ["type", "PolicyMachineStorageAdapter::ActiveRecord::Object"]]
D, [2021-10-12T14:50:17.739148 #14279] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::PolicyElement Load (1.1ms)  SELECT "policy_elements".* FROM "policy_elements" WHERE (          id IN (
            WITH RECURSIVE assignments_recursive AS (
              (
                SELECT parent_id, child_id
                FROM assignments
                WHERE child_id IN (8,13)
              )
              UNION ALL
              (
                SELECT assignments.parent_id, assignments.child_id
                FROM assignments
                INNER JOIN assignments_recursive
                ON assignments_recursive.parent_id = assignments.child_id
              )
            )

            SELECT assignments_recursive.parent_id
            FROM assignments_recursive
          )
) AND "policy_elements"."type" = $1  [["type", "PolicyMachineStorageAdapter::ActiveRecord::Object"]]
D, [2021-10-12T14:50:17.742030 #14279] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::Operation Load (0.2ms)  SELECT "policy_elements".* FROM "policy_elements" WHERE "policy_elements"."type" = $1 AND "policy_elements"."unique_identifier" = $2 LIMIT $3  [["type", "PolicyMachineStorageAdapter::ActiveRecord::Operation"], ["unique_identifier", "~create"], ["LIMIT", 1]]
```
</details>

<details>
  <summary>After</summary>

```SQL
D, [2021-10-14T10:07:33.846207 #25934] DEBUG -- :    (0.9ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE (          id IN (
            WITH RECURSIVE assignments_recursive AS (
              (
                SELECT child_id, parent_id
                FROM assignments
                WHERE parent_id in (1)
              )
              UNION ALL
              (
                SELECT assignments.child_id, assignments.parent_id
                FROM assignments
                INNER JOIN assignments_recursive
                ON assignments_recursive.child_id = assignments.parent_id
              )
            )

            SELECT assignments_recursive.child_id
            FROM assignments_recursive
          )
) AND "policy_elements"."color" = $1  [["color", "purple"]]
D, [2021-10-14T10:07:33.847884 #25934] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::PolicyElementAssociation Load (0.6ms)  SELECT "policy_element_associations".* FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN ($1, $2)  [["user_attribute_id", 2], ["user_attribute_id", 1]]
D, [2021-10-14T10:07:33.849680 #25934] DEBUG -- :    (0.9ms)  SELECT "policy_element_associations"."object_attribute_id" FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN ($1, $2) AND (          operation_set_id IN (
            WITH RECURSIVE accessible_operations AS (
              (
                SELECT
                  child_id,
                  parent_id,
                  parent_id AS operation_set_id
                FROM assignments
                WHERE parent_id IN (SELECT "policy_element_associations"."operation_set_id" FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN (2, 1))
              )
              UNION ALL
              (
                SELECT
                  assignments.child_id,
                  assignments.parent_id,
                  accessible_operations.operation_set_id AS operation_set_id
                FROM assignments
                INNER JOIN accessible_operations
                  ON accessible_operations.child_id = assignments.parent_id
              )
            )

            SELECT accessible_operations.operation_set_id
            FROM accessible_operations
            JOIN policy_elements ops
              ON ops.id = accessible_operations.child_id
            WHERE ops.unique_identifier = 'create'
          )
)  [["user_attribute_id", 2], ["user_attribute_id", 1]]
D, [2021-10-14T10:07:33.851194 #25934] DEBUG -- :    (0.2ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE "policy_elements"."id" = $1 AND "policy_elements"."type" = $2  [["id", 13], ["type", "PolicyMachineStorageAdapter::ActiveRecord::Object"]]
D, [2021-10-14T10:07:33.852209 #25934] DEBUG -- :    (0.2ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE "policy_elements"."id" = $1  [["id", 13]]
D, [2021-10-14T10:07:33.853577 #25934] DEBUG -- :    (0.6ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE (          id IN (
            WITH RECURSIVE assignments_recursive AS (
              (
                SELECT parent_id, child_id
                FROM assignments
                WHERE child_id IN (13)
              )
              UNION ALL
              (
                SELECT assignments.parent_id, assignments.child_id
                FROM assignments
                INNER JOIN assignments_recursive
                ON assignments_recursive.parent_id = assignments.child_id
              )
            )

            SELECT assignments_recursive.parent_id
            FROM assignments_recursive
          )
) AND "policy_elements"."type" = $1  [["type", "PolicyMachineStorageAdapter::ActiveRecord::Object"]]
D, [2021-10-14T10:07:33.855439 #25934] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::PolicyElement Load (0.6ms)  SELECT "policy_elements".* FROM "policy_elements" WHERE "policy_elements"."id" IN ($1, $2)  [["id", 14], ["id", 12]]
```
</details>

<details>
  <summary>With Fields</summary>

```SQL
D, [2021-10-14T10:08:29.008997 #26395] DEBUG -- :    (1.0ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE (          id IN (
            WITH RECURSIVE assignments_recursive AS (
              (
                SELECT child_id, parent_id
                FROM assignments
                WHERE parent_id in (1)
              )
              UNION ALL
              (
                SELECT assignments.child_id, assignments.parent_id
                FROM assignments
                INNER JOIN assignments_recursive
                ON assignments_recursive.child_id = assignments.parent_id
              )
            )

            SELECT assignments_recursive.child_id
            FROM assignments_recursive
          )
)
D, [2021-10-14T10:08:29.012935 #26395] DEBUG -- :   PolicyMachineStorageAdapter::ActiveRecord::PolicyElementAssociation Load (0.6ms)  SELECT "policy_element_associations".* FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN ($1, $2, $3, $4)  [["user_attribute_id", 2], ["user_attribute_id", 3], ["user_attribute_id", 4], ["user_attribute_id", 1]]
D, [2021-10-14T10:08:29.015787 #26395] DEBUG -- :    (1.2ms)  SELECT "policy_element_associations"."object_attribute_id" FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN ($1, $2, $3, $4) AND (          operation_set_id IN (
            WITH RECURSIVE accessible_operations AS (
              (
                SELECT
                  child_id,
                  parent_id,
                  parent_id AS operation_set_id
                FROM assignments
                WHERE parent_id IN (SELECT "policy_element_associations"."operation_set_id" FROM "policy_element_associations" WHERE "policy_element_associations"."user_attribute_id" IN (2, 3, 4, 1))
              )
              UNION ALL
              (
                SELECT
                  assignments.child_id,
                  assignments.parent_id,
                  accessible_operations.operation_set_id AS operation_set_id
                FROM assignments
                INNER JOIN accessible_operations
                  ON accessible_operations.child_id = assignments.parent_id
              )
            )

            SELECT accessible_operations.operation_set_id
            FROM accessible_operations
            JOIN policy_elements ops
              ON ops.id = accessible_operations.child_id
            WHERE ops.unique_identifier = 'create'
          )
)  [["user_attribute_id", 2], ["user_attribute_id", 3], ["user_attribute_id", 4], ["user_attribute_id", 1]]
D, [2021-10-14T10:08:29.019275 #26395] DEBUG -- :    (0.5ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE "policy_elements"."id" IN ($1, $2) AND "policy_elements"."type" = $3  [["id", 13], ["id", 8], ["type", "PolicyMachineStorageAdapter::ActiveRecord::Object"]]
D, [2021-10-14T10:08:29.020501 #26395] DEBUG -- :    (0.8ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE "policy_elements"."id" IN ($1, $2)  [["id", 13], ["id", 8]]
D, [2021-10-14T10:08:29.023642 #26395] DEBUG -- :    (0.8ms)  SELECT "policy_elements"."id" FROM "policy_elements" WHERE (          id IN (
            WITH RECURSIVE assignments_recursive AS (
              (
                SELECT parent_id, child_id
                FROM assignments
                WHERE child_id IN (8,13)
              )
              UNION ALL
              (
                SELECT assignments.parent_id, assignments.child_id
                FROM assignments
                INNER JOIN assignments_recursive
                ON assignments_recursive.parent_id = assignments.child_id
              )
            )

            SELECT assignments_recursive.parent_id
            FROM assignments_recursive
          )
) AND "policy_elements"."type" = $1  [["type", "PolicyMachineStorageAdapter::ActiveRecord::Object"]]
D, [2021-10-14T10:08:29.026012 #26395] DEBUG -- :    (0.4ms)  SELECT "policy_elements"."unique_identifier", "policy_elements"."policy_machine_uuid" FROM "policy_elements" WHERE "policy_elements"."id" IN ($1, $2, $3, $4, $5, $6)  [["id", 11], ["id", 9], ["id", 10], ["id", 14], ["id", 7], ["id", 12]]
```
</details>

<hr/>

`#accessible_objects_for_operations`

* Added `fields` to `#build_accessible_object_scope`.
* Used `pluck` here for notable performance gains for highly assigned operables as noted in [investigation](https://github.com/mdsol/kjerinsky-mdsol-notes/tree/notes/mcc/MCC-814213%20Investigate%20slow%20left-side%20PM%20calculation).
* The method is getting long in the tooth. I would prefer to not spend the effort refactoring it down when we are going to replace it with a more performant database call in the future.

@mdsol/team04 