### PR TITLE
[MCC-833873] Add distinct to pg function for accessible_objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.1
+* Updated PostgreSQL function `pm_accessible_objects_for_operations` to ensure uniqueness of results
+
 ## 4.0.0
 * Added a PostgreSQL function for `#accessible_objects` and `#accessible_objects_for_operations` which are performance
 optimized. Only supported for a single `field`, `direct_only`, and `ignore_prohibitions`.

--- a/lib/migrations/accessible_objects_for_operations_function.rb
+++ b/lib/migrations/accessible_objects_for_operations_function.rb
@@ -117,7 +117,7 @@ class AccessibleObjectsForOperationsFunction < ActiveRecord::Migration[5.2]
 
         RETURN QUERY EXECUTE
         format(
-          'SELECT os.unique_identifier, array_agg(pe.%I) AS objects ' ||
+          'SELECT os.unique_identifier, array_agg(DISTINCT pe.%I) AS objects ' ||
           'FROM ' ||
           '  t_operation_set_ids os_id ' ||
           '  JOIN t_operation_sets os ON os.operation_set_id = os_id.operation_set_id ' ||

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 end


### PR DESCRIPTION
Adds distinct to the arrays returned.

Related #190 