### PR TITLE
[MCC-833873] Fix single pg call for accessible_objects from replica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## 4.0.2
+* Updated `accessible_objects_for_operations` code path to use a CTE when using a replica database.
+
 ## 4.0.1
-* Updated PostgreSQL function `pm_accessible_objects_for_operations` to ensure uniqueness of results
+* Updated PostgreSQL function `pm_accessible_objects_for_operations` to ensure uniqueness of results.
 
 ## 4.0.0
-* Added a PostgreSQL function for `#accessible_objects` and `#accessible_objects_for_operations` which are performance
+* Added a PostgreSQL function for `#accessible_objects` and `#accessible_objects_for_operations` which are performance.
 optimized. Only supported for a single `field`, `direct_only`, and `ignore_prohibitions`.
 
 – Execute `bundle exec rails generate the_policy_machine:accessible_objects_for_operations_function` and rerun

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "4.0.1"
+  VERSION = "4.0.2"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -68,6 +68,14 @@ module PolicyMachineStorageAdapter
         end
     end
 
+    def self.connection_db_config
+      if ::ActiveRecord::Base.respond_to?(:connection_db_config)
+        ::ActiveRecord::Base.connection_db_config.configuration_hash
+      else
+        ::ActiveRecord::Base.connection_config
+      end
+    end
+
     def self.buffering?
       @buffering
     end

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -192,7 +192,7 @@ module PolicyMachineStorageAdapter
                     pe.id = os_id.object_attribute_id
                     AND "type" = 'PolicyMachineStorageAdapter::ActiveRecord::Object'
                 )
-              ), NULL) AS uris
+              ), NULL) AS objects
             FROM
               operation_set_ids os_id
               JOIN operation_sets os ON os.operation_set_id = os_id.operation_set_id
@@ -200,7 +200,7 @@ module PolicyMachineStorageAdapter
           )
           SELECT
             unique_identifier,
-            ARRAY(SELECT DISTINCT o FROM UNNEST(uris) AS a(o)) as objects
+            ARRAY(SELECT DISTINCT o FROM UNNEST(objects) AS a(o)) as objects
           FROM operation_objects;
         SQL
       end

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -81,7 +81,7 @@ module PolicyMachineStorageAdapter
         filters = options.dig(:filters, :user_attributes) || {}
 
         query =
-          if readonly?
+          if replica?
             sanitize_sql_for_assignment([
               accessible_objects_for_operations_cte(field, filters),
               user_id,
@@ -217,8 +217,8 @@ module PolicyMachineStorageAdapter
         condition.chomp('AND ') << ')'
       end
 
-      def self.readonly?
-        ::ActiveRecord::Base.connection_config[:replica] == true
+      def self.replica?
+        ::ActiveRecord::Base.connection_db_config.configuration_hash[:replica] == true
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -218,7 +218,7 @@ module PolicyMachineStorageAdapter
       end
 
       def self.replica?
-        ::ActiveRecord::Base.connection_db_config.configuration_hash[:replica] == true
+        ActiveRecord.db_config[:replica] == true
       end
     end
 

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -218,7 +218,7 @@ module PolicyMachineStorageAdapter
       end
 
       def self.replica?
-        ActiveRecord.db_config[:replica] == true
+        ActiveRecord.connection_db_config[:replica] == true
       end
     end
 

--- a/policy_machine.gemspec
+++ b/policy_machine.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('byebug')
   s.add_development_dependency('neography', '~> 1.1')
   s.add_development_dependency('database_cleaner')
-  s.add_development_dependency('rails', '~> 6.0')
+  s.add_development_dependency('rails', '~> 6.1')
 end

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -866,7 +866,7 @@ describe 'ActiveRecord' do
       describe 'accessible_objects_for_operations_cte' do
         before do
           allow(PolicyMachineStorageAdapter::ActiveRecord::PolicyElement)
-            .to receive(:readonly?).and_return(true)
+            .to receive(:replica?).and_return(true)
         end
 
         it_behaves_like 'a single query for accessible objects'

--- a/spec/policy_machine_storage_adapters/active_record_spec.rb
+++ b/spec/policy_machine_storage_adapters/active_record_spec.rb
@@ -741,23 +741,10 @@ describe 'ActiveRecord' do
         end
       end
 
-      describe 'accessible_objects_for_operations_function' do
+      shared_examples 'a single query for accessible objects' do
         before do
           priv_pm.add_association(color_1, creator, object_6)
           priv_pm.add_association(color_2, creator, object_7)
-        end
-
-        it 'uses a PostgreSQL function' do
-          expect_any_instance_of(PolicyMachineStorageAdapter::ActiveRecord)
-            .to receive(:accessible_objects_for_operations_function)
-
-          priv_pm.accessible_objects_for_operations(
-            user_1,
-            [create, paint],
-            direct_only: true,
-            ignore_prohibitions: true,
-            fields: [:unique_identifier]
-          )
         end
 
         it 'returns objects accessible via each of multiple given operations' do
@@ -856,6 +843,46 @@ describe 'ActiveRecord' do
               paint.to_s => ['object_6'],
             })
           end
+        end
+      end
+
+      describe 'accessible_objects_for_operations_function' do
+        it_behaves_like 'a single query for accessible objects'
+
+        it 'uses a PostgreSQL function' do
+          expect_any_instance_of(PolicyMachineStorageAdapter::ActiveRecord)
+            .to receive(:accessible_objects_for_operations_function)
+
+          priv_pm.accessible_objects_for_operations(
+            user_1,
+            [create, paint],
+            direct_only: true,
+            ignore_prohibitions: true,
+            fields: [:unique_identifier]
+          )
+        end
+      end
+
+      describe 'accessible_objects_for_operations_cte' do
+        before do
+          allow(PolicyMachineStorageAdapter::ActiveRecord::PolicyElement)
+            .to receive(:readonly?).and_return(true)
+        end
+
+        it_behaves_like 'a single query for accessible objects'
+
+        it 'uses a single CTE' do
+          expect(PolicyMachineStorageAdapter::ActiveRecord::PolicyElement)
+            .to receive(:accessible_objects_for_operations_cte)
+            .and_call_original
+
+          priv_pm.accessible_objects_for_operations(
+            user_1,
+            [create, paint],
+            direct_only: true,
+            ignore_prohibitions: true,
+            fields: [:unique_identifier]
+          )
         end
       end
 


### PR DESCRIPTION
PostgreSQL has restrictions on creating temporary tables on replica databases. Adding in the CTE that was used in previous benchmark investigations for use when the database connection a replica.

Benchmarks for 50k user

Single run

| method version | user     | system   | total    | real     | faster |
| ---            | ---:     | ---:     | ---:     | ---:     | ---:   |
| no pluck       | 3.163534 | 0.151665 | 3.315199 | 3.845629 |        |
| pluck          | 1.610845 | 0.035368 | 1.646213 | 2.271648 | 40.1%  |
| pg function    | 0.020938 | 0.012064 | 0.033002 | 0.452649 | 88.2%  |
| cte            | 0.041312 | 0.007820 | 0.049132 | 0.624768 | 83.8%  |

Multiple runs (5)

| method version | user      | system   | total     | real      | faster |
| ---            | ---:      | ---:     | ---:      | ---:      | ---:   |
| no pluck       | 17.658298 | 0.479222 | 18.137520 | 21.150227 |        |
| pluck          | 7.143887  | 0.198251 | 7.342138  | 10.431428 | 50.7%  |
| pg function    | 0.182273  | 0.055765 | 0.238038  | 2.381902  | 88.7%  |
| cte            | 0.163428  | 0.039802 | 0.203230  | 3.082762  | 85.4%  |