### PR TITLE
[MCC-893601] Performance optimization for `accessible_operations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.3
+* Updated PostgreSQL `operations_for_operation_sets` CTE to pre-aggregate `accessible_operations` before joining to
+`policy_elements` for performance optimizations.
+
 ## 4.0.2
 * Updated `accessible_objects_for_operations` code path to use a CTE when using a replica database.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "4.0.2"
+  VERSION = "4.0.3"
 end


### PR DESCRIPTION
The query using the `accessible_operations` CTE was averaging 250+ ms in our production environments. Cherry picked recent examples from our test environment are being logged as taking around 2 seconds right now. Using the same parameters from those cherry picked examples was yielding around 300ms when called directly on the database.

It was found that pre-filtering inside the `WHERE` clause before joining on the `policy_elements` table allowed to swap out some more costly `Parallel Bitmap Heap Scan` for a `HashAggregate`/`Index Scan`

The result was a consistently 300+ ms query improved to 5ms.

---

### EXPLAIN ANALYZE

<details>
<summary>Before</summary>

```sql
Unique  (cost=5548314.36..5549644.57 rows=177362 width=41) (actual time=324.073..326.136 rows=455 loops=1)
  CTE accessible_operations
    ->  Recursive Union  (cost=0.56..3086767.28 rows=4209538 width=12) (actual time=0.016..3.167 rows=891 loops=1)
          ->  Index Only Scan using index_assignments_on_parent_id_and_child_id on assignments  (cost=0.56..1632.11 rows=978 width=12) (actual time=0.015..0.147 rows=75 loops=1)
                Index Cond: (parent_id = ANY ('{1,2,3}'::integer[]))
                Heap Fetches: 72
          ->  Nested Loop  (cost=0.56..300094.44 rows=420856 width=12) (actual time=1.063..1.428 rows=408 loops=2)
                ->  WorkTable Scan on accessible_operations accessible_operations_1  (cost=0.00..195.60 rows=9780 width=8) (actual time=0.001..0.049 rows=446 loops=2)
                ->  Index Only Scan using index_assignments_on_parent_id_and_child_id on assignments assignments_1  (cost=0.56..30.23 rows=43 width=8) (actual time=0.002..0.003 rows=1 loops=891)
                      Index Cond: (parent_id = accessible_operations_1.child_id)
                      Heap Fetches: 816
  ->  Sort  (cost=2461547.08..2461990.48 rows=177362 width=41) (actual time=324.073..326.027 rows=821 loops=1)
        Sort Key: accessible_operations.operation_set_id, ops.unique_identifier
        Sort Method: quicksort  Memory: 90kB
        ->  Hash Join  (cost=2308158.06..2440627.86 rows=177362 width=41) (actual time=265.412..324.982 rows=821 loops=1)
              Hash Cond: (accessible_operations.child_id = ops.id)
              ->  CTE Scan on accessible_operations  (cost=0.00..84190.76 rows=4209538 width=8) (actual time=0.017..3.514 rows=891 loops=1)
              ->  Hash  (cost=2297644.55..2297644.55 rows=493801 width=41) (actual time=264.909..266.824 rows=492167 loops=1)
                    Buckets: 65536  Batches: 16  Memory Usage: 3386kB
                    ->  Gather  (cost=576915.64..2297644.55 rows=493801 width=41) (actual time=55.711..159.391 rows=492167 loops=1)
                          Workers Planned: 2
                          Workers Launched: 2
                          ->  Parallel Bitmap Heap Scan on policy_elements ops  (cost=575915.64..2247264.45 rows=205750 width=41) (actual time=52.067..151.492 rows=164056 loops=3)
                                Recheck Cond: ((type)::text = 'PolicyMachineStorageAdapter::ActiveRecord::Operation'::text)
                                Rows Removed by Index Recheck: 193356
                                Heap Blocks: exact=4064 lossy=4067
                                ->  Bitmap Index Scan on index_policy_elements_on_type  (cost=0.00..575792.19 rows=493801 width=0) (actual time=46.151..46.151 rows=492169 loops=1)
                                      Index Cond: ((type)::text = 'PolicyMachineStorageAdapter::ActiveRecord::Operation'::text)
Planning Time: 0.252 ms
Execution Time: 326.222 ms
```
</details>

<details>
<summary>After</summary>

```sql
Unique  (cost=3329080.49..3329558.27 rows=63704 width=41) (actual time=5.004..5.154 rows=455 loops=1)
  CTE accessible_operations
    ->  Recursive Union  (cost=0.56..3086767.28 rows=4209538 width=12) (actual time=0.018..1.969 rows=891 loops=1)
          ->  Index Only Scan using index_assignments_on_parent_id_and_child_id on assignments  (cost=0.56..1632.11 rows=978 width=12) (actual time=0.017..0.131 rows=75 loops=1)
                Index Cond: (parent_id = ANY ('{1,2,3}'::integer[]))
                Heap Fetches: 72
          ->  Nested Loop  (cost=0.56..300094.44 rows=420856 width=12) (actual time=0.628..0.860 rows=408 loops=2)
                ->  WorkTable Scan on accessible_operations accessible_operations_2  (cost=0.00..195.60 rows=9780 width=8) (actual time=0.000..0.025 rows=446 loops=2)
                ->  Index Only Scan using index_assignments_on_parent_id_and_child_id on assignments assignments_1  (cost=0.56..30.23 rows=43 width=8) (actual time=0.001..0.002 rows=1 loops=891)
                      Index Cond: (parent_id = accessible_operations_2.child_id)
                      Heap Fetches: 816
  ->  Sort  (cost=242313.21..242472.47 rows=63704 width=41) (actual time=5.003..5.043 rows=821 loops=1)
        Sort Key: accessible_operations.operation_set_id, ops.unique_identifier
        Sort Method: quicksort  Memory: 90kB
        ->  Hash Join  (cost=100209.35..235269.92 rows=63704 width=41) (actual time=3.349..3.978 rows=821 loops=1)
              Hash Cond: (accessible_operations.child_id = ops.id)
              ->  CTE Scan on accessible_operations  (cost=0.00..84190.76 rows=4209538 width=8) (actual time=0.019..0.116 rows=891 loops=1)
              ->  Hash  (cost=96433.32..96433.32 rows=177362 width=45) (actual time=3.215..3.216 rows=211 loops=1)
                    Buckets: 65536  Batches: 4  Memory Usage: 516kB
                    ->  Nested Loop  (cost=94715.16..96433.32 rows=177362 width=45) (actual time=2.313..3.111 rows=211 loops=1)
                          ->  HashAggregate  (cost=94714.60..94716.60 rows=200 width=4) (actual time=2.302..2.339 rows=251 loops=1)
                                Group Key: accessible_operations_1.child_id
                                Batches: 1  Memory Usage: 61kB
                                ->  CTE Scan on accessible_operations accessible_operations_1  (cost=0.00..84190.76 rows=4209538 width=4) (actual time=0.001..2.136 rows=891 loops=1)
                          ->  Index Scan using policy_elements_pkey on policy_elements ops  (cost=0.56..8.58 rows=1 width=41) (actual time=0.003..0.003 rows=1 loops=251)
                                Index Cond: (id = accessible_operations_1.child_id)
                                Filter: ((type)::text = 'PolicyMachineStorageAdapter::ActiveRecord::Operation'::text)
                                Rows Removed by Filter: 0
Planning Time: 0.342 ms
Execution Time: 5.234 ms
```
</details>