### PR TITLE
Handle empty extra attributes so that we can "includes" plain old AR assocations to PE objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.6
+* Fallback to empty hash when extra_attributes are not set.
+
 ## 4.0.5
 * Support ruby 3.
 

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "4.0.5"
+  VERSION = "4.0.6"
 end

--- a/lib/policy_machine_storage_adapters/active_record.rb
+++ b/lib/policy_machine_storage_adapters/active_record.rb
@@ -183,7 +183,7 @@ module PolicyMachineStorageAdapter
       # Uses ActiveRecord's store method to methodize new attribute keys in extra_attributes
       def store_attributes
         # Do not overwrite accessors for existing columns
-        @extra_attributes_hash = extra_attributes
+        @extra_attributes_hash = extra_attributes || {}
         column_attributes = PolicyElement.column_names.map(&:to_sym)
         self.class.store_accessor(:extra_attributes, @extra_attributes_hash.except(column_attributes).keys)
       end


### PR DESCRIPTION
here be dragons

