### PR TITLE
[MCC-1138928] Ensure no mergejoin for operations_for_operation_sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.1.1
+* Updated PostgreSQL `operations_for_operation_sets` to guarantee disable mergejoin
+
 ## 4.1.0
 * Support Rails 7.1
 * Drop support for Rails < 7.1

--- a/lib/policy_machine/version.rb
+++ b/lib/policy_machine/version.rb
@@ -1,3 +1,3 @@
 class PolicyMachine
-  VERSION = "4.1.0"
+  VERSION = "4.1.1"
 end

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -8,6 +8,8 @@ module PolicyMachineStorageAdapter
       # optionally can give a list of operation names to filter by
       def self.operations_for_operation_sets(operation_set_ids, operation_names = nil)
         query = <<~SQL
+          SET LOCAL enable_mergejoin TO FALSE;
+
           WITH RECURSIVE accessible_operations AS (
             (
               SELECT
@@ -36,11 +38,11 @@ module PolicyMachineStorageAdapter
         sanitize_arg = [query, operation_set_ids]
 
         if operation_names
-          query << "AND ops.unique_identifier IN (?)"
+          query << "AND ops.unique_identifier IN (?);"
           sanitize_arg << operation_names
         else
           type = PolicyMachineStorageAdapter::ActiveRecord.class_for_type('operation').name
-          query << "AND ops.type = '#{type}'"
+          query << "AND ops.type = '#{type}';"
         end
 
         sanitized_query = sanitize_sql_for_assignment(sanitize_arg)
@@ -71,7 +73,6 @@ module PolicyMachineStorageAdapter
         #   { 'operation_set_id' => 789, 'unique_identifier' => 'operation3' },
         # ]
         connection.transaction do
-          connection.execute('SET LOCAL enable_mergejoin TO FALSE')
           connection.execute(sanitized_query)
         end
       end

--- a/lib/policy_machine_storage_adapters/active_record/postgresql.rb
+++ b/lib/policy_machine_storage_adapters/active_record/postgresql.rb
@@ -70,7 +70,10 @@ module PolicyMachineStorageAdapter
         #   { 'operation_set_id' => 789, 'unique_identifier' => 'operation2' },
         #   { 'operation_set_id' => 789, 'unique_identifier' => 'operation3' },
         # ]
-        connection.execute(sanitized_query)
+        connection.transaction do
+          connection.execute('SET LOCAL enable_mergejoin TO FALSE')
+          connection.execute(sanitized_query)
+        end
       end
 
       # The PG function can only accept a single field for now.


### PR DESCRIPTION
Notes are linked in the ticket

@mdsol/platform-scalability 